### PR TITLE
perf: eliminate deep cloning in lexer, merger, and splitter hot paths

### DIFF
--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -8,7 +8,7 @@ use crate::rules;
 /// for a specific SQL variant.
 pub trait Dialect: Send + Sync {
     /// Get the lexing rules for this dialect.
-    fn get_rules(&self) -> Vec<Rule>;
+    fn get_rules(&self) -> &'static [Rule];
 
     /// Whether identifiers are case-sensitive.
     fn case_sensitive_names(&self) -> bool {
@@ -27,7 +27,7 @@ pub trait Dialect: Send + Sync {
 pub struct Polyglot;
 
 impl Dialect for Polyglot {
-    fn get_rules(&self) -> Vec<Rule> {
+    fn get_rules(&self) -> &'static [Rule] {
         rules::main_rules()
     }
 }
@@ -38,7 +38,7 @@ impl Dialect for Polyglot {
 pub struct ClickHouse;
 
 impl Dialect for ClickHouse {
-    fn get_rules(&self) -> Vec<Rule> {
+    fn get_rules(&self) -> &'static [Rule] {
         rules::main_rules()
     }
 }
@@ -48,7 +48,7 @@ impl Dialect for ClickHouse {
 pub struct DuckDb;
 
 impl Dialect for DuckDb {
-    fn get_rules(&self) -> Vec<Rule> {
+    fn get_rules(&self) -> &'static [Rule] {
         rules::main_rules()
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -48,8 +48,9 @@ impl QueryFormatter {
     /// Stage 1: Split lines based on SQL structure.
     fn split_lines(&self, query: &mut Query, arena: &mut Vec<Node>) {
         let splitter = LineSplitter::new();
-        let mut new_lines = Vec::new();
-        for line in &query.lines {
+        let old_lines = std::mem::take(&mut query.lines);
+        let mut new_lines = Vec::with_capacity(old_lines.len() * 2);
+        for line in old_lines {
             new_lines.extend(splitter.maybe_split(line, arena));
         }
         query.lines = new_lines;

--- a/src/line.rs
+++ b/src/line.rs
@@ -91,7 +91,7 @@ impl Line {
         if self.has_formatting_disabled() {
             return self.render_formatting_disabled(arena);
         }
-        let mut result = String::new();
+        let mut result = String::with_capacity(self.indent_size(arena) + 80);
         let mut first_content = true;
         for &idx in &self.nodes {
             let node = &arena[idx];

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -36,7 +36,8 @@ impl LineMerger {
 
                 if segments.len() > 1 {
                     let segments = self.fix_standalone_operators(segments, arena);
-                    let segments = self.maybe_merge_operators(segments, OperatorPrecedence::tiers(), arena);
+                    let segments =
+                        self.maybe_merge_operators(segments, OperatorPrecedence::tiers(), arena);
                     let segments = self.maybe_stubbornly_merge(segments, arena);
                     for segment in &segments {
                         merged_lines.extend(self.maybe_merge_lines(&segment.lines, arena));

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -36,8 +36,7 @@ impl LineMerger {
 
                 if segments.len() > 1 {
                     let segments = self.fix_standalone_operators(segments, arena);
-                    let tiers = OperatorPrecedence::tiers().to_vec();
-                    let segments = self.maybe_merge_operators(segments, tiers, arena);
+                    let segments = self.maybe_merge_operators(segments, OperatorPrecedence::tiers(), arena);
                     let segments = self.maybe_stubbornly_merge(segments, arena);
                     for segment in &segments {
                         merged_lines.extend(self.maybe_merge_lines(&segment.lines, arena));
@@ -431,15 +430,16 @@ impl LineMerger {
     fn maybe_merge_operators(
         &self,
         segments: Vec<Segment>,
-        mut op_tiers: Vec<OperatorPrecedence>,
+        op_tiers: &[OperatorPrecedence],
         arena: &[Node],
     ) -> Vec<Segment> {
-        let Some(precedence) = op_tiers.pop() else {
+        let Some(&precedence) = op_tiers.last() else {
             return segments;
         };
         if segments.len() <= 1 {
             return segments;
         }
+        let remaining_tiers = &op_tiers[..op_tiers.len() - 1];
         let mut new_segments: Vec<Segment> = Vec::new();
         let mut head = 0;
 
@@ -447,13 +447,17 @@ impl LineMerger {
             if !self.segment_continues_operator_sequence(&segments[i], precedence, arena) {
                 new_segments.extend(self.try_merge_operator_segments(
                     &segments[head..i],
-                    op_tiers.clone(),
+                    remaining_tiers,
                     arena,
                 ));
                 head = i;
             }
         }
-        new_segments.extend(self.try_merge_operator_segments(&segments[head..], op_tiers, arena));
+        new_segments.extend(self.try_merge_operator_segments(
+            &segments[head..],
+            remaining_tiers,
+            arena,
+        ));
 
         new_segments
     }
@@ -565,7 +569,7 @@ impl LineMerger {
     fn try_merge_operator_segments(
         &self,
         segments: &[Segment],
-        op_tiers: Vec<OperatorPrecedence>,
+        op_tiers: &[OperatorPrecedence],
         arena: &[Node],
     ) -> Vec<Segment> {
         if segments.len() <= 1 {
@@ -599,7 +603,7 @@ impl LineMerger {
                 OperatorPrecedence::OtherTight,
                 arena,
             ) {
-                new_segments = self.stubbornly_merge(&new_segments, &segment, arena);
+                new_segments = self.stubbornly_merge(new_segments, segment, arena);
             } else {
                 new_segments.push(segment);
             }
@@ -628,7 +632,7 @@ impl LineMerger {
                 && Segment::new(self.safe_create_merged_line(&segment.lines, arena))
                     .tail_closes_head(arena)
             {
-                new_segments = self.stubbornly_merge(&new_segments, &segment, arena);
+                new_segments = self.stubbornly_merge(new_segments, segment, arena);
             } else {
                 new_segments.push(segment);
             }
@@ -639,19 +643,23 @@ impl LineMerger {
         }
 
         // Phase 3 needs indexed access for look-ahead (segments.get(i + 1)),
-        // so we keep indexed iteration here.
-        let segments = new_segments;
+        // so we consume via drain to avoid cloning.
+        let mut segments = new_segments;
         let mut new_segments = Vec::with_capacity(segments.len());
-        new_segments.push(segments[0].clone());
+        // Take first element by swap-remove pattern
+        let first = std::mem::replace(&mut segments[0], Segment::new(Vec::new()));
+        new_segments.push(first);
         for i in 1..segments.len() {
             let prev = new_segments
                 .last()
                 .expect("new_segments initialized with segments[0]");
             let next = segments.get(i + 1);
             if self.segment_should_stubbornly_merge(&segments[i], prev, next, arena) {
-                new_segments = self.stubbornly_merge(&new_segments, &segments[i], arena);
+                let seg = std::mem::replace(&mut segments[i], Segment::new(Vec::new()));
+                new_segments = self.stubbornly_merge(new_segments, seg, arena);
             } else {
-                new_segments.push(segments[i].clone());
+                let seg = std::mem::replace(&mut segments[i], Segment::new(Vec::new()));
+                new_segments.push(seg);
             }
         }
 
@@ -659,30 +667,29 @@ impl LineMerger {
     }
 
     /// Attempt several methods of merging a segment with the previous segments.
+    /// Takes ownership of both `prev_segments` and `segment` to avoid cloning.
     fn stubbornly_merge(
         &self,
-        prev_segments: &[Segment],
-        segment: &Segment,
+        mut prev_segments: Vec<Segment>,
+        segment: Segment,
         arena: &[Node],
     ) -> Vec<Segment> {
-        let mut new_segments = prev_segments.to_vec();
-        let prev_segment = match new_segments.pop() {
+        let prev_segment = match prev_segments.pop() {
             Some(s) => s,
             None => {
-                new_segments.push(segment.clone());
-                return new_segments;
+                prev_segments.push(segment);
+                return prev_segments;
             }
         };
 
-        let head = match segment.head(arena) {
+        let (head_idx, head_line) = match segment.head(arena) {
             Ok((head_idx, head_line)) => (head_idx, head_line.clone()),
             Err(_) => {
-                new_segments.push(prev_segment);
-                new_segments.push(segment.clone());
-                return new_segments;
+                prev_segments.push(prev_segment);
+                prev_segments.push(segment);
+                return prev_segments;
             }
         };
-        let (head_idx, head_line) = head;
 
         let mut try_lines = Vec::with_capacity(prev_segment.lines.len() + 1);
         try_lines.extend_from_slice(&prev_segment.lines);
@@ -692,8 +699,8 @@ impl LineMerger {
             result_seg
                 .lines
                 .extend_from_slice(&segment.lines[head_idx + 1..]);
-            new_segments.push(result_seg);
-            return new_segments;
+            prev_segments.push(result_seg);
+            return prev_segments;
         }
 
         if let Ok((tail_idx, tail_line)) = prev_segment.tail(arena) {
@@ -704,8 +711,8 @@ impl LineMerger {
                 let tail_start = prev_segment.lines.len() - 1 - tail_idx;
                 let mut result_seg = Segment::new(prev_segment.lines[..tail_start].to_vec());
                 result_seg.lines.extend(merged);
-                new_segments.push(result_seg);
-                return new_segments;
+                prev_segments.push(result_seg);
+                return prev_segments;
             }
 
             let try_lines = vec![tail_line.clone(), head_line];
@@ -716,14 +723,14 @@ impl LineMerger {
                 result_seg
                     .lines
                     .extend_from_slice(&segment.lines[head_idx + 1..]);
-                new_segments.push(result_seg);
-                return new_segments;
+                prev_segments.push(result_seg);
+                return prev_segments;
             }
         }
 
-        new_segments.push(prev_segment);
-        new_segments.push(segment.clone());
-        new_segments
+        prev_segments.push(prev_segment);
+        prev_segments.push(segment);
+        prev_segments
     }
 }
 

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -4,7 +4,9 @@ use crate::action::Action;
 
 /// A lexing rule: name, priority, compiled regex, and action.
 /// Rules are tried in ascending priority order; first match wins.
-#[derive(Clone)]
+///
+/// Rules are constructed once in `LazyLock` statics and referenced via
+/// `&'static [Rule]`, so `Clone` is not needed.
 pub struct Rule {
     pub name: String,
     pub priority: u32,


### PR DESCRIPTION
Phase 1 - Static Rules + Zero-Clone Lexer:
- Change rule_stack from Vec<Vec<Rule>> to Vec<&'static [Rule]>, eliminating
  rule cloning on every ruleset push/access
- Remove rule.action.clone() in lex_one hot path (~3000 clones per large file)
  by using &'static Action references that don't borrow from self
- Change Action's Box<Action> to &'static Action and String to &'static str
- Return &'static [Rule] from all rule accessor functions instead of Vec<Rule>

Phase 2 - Zero-alloc Operator Precedence:
- Replace to_ascii_lowercase() + split_whitespace().join() string allocations
  with zero-alloc eq_ignore_ascii_case() and eq_ignore_case_ws() comparisons
- Eliminates 2 String allocations per operator precedence check during merging

Phase 3 - Reduce Merger Cloning:
- Change maybe_merge_operators/try_merge_operator_segments to take &[OperatorPrecedence]
  slices instead of cloning Vec<OperatorPrecedence> on each recursion
- Change stubbornly_merge to take ownership of segments (Vec<Segment>, Segment)
  instead of borrowing and cloning
- Use std::mem::replace to consume segments by value in maybe_stubbornly_merge
- Change splitter.maybe_split() to take Line by value, avoiding clone for
  formatting-disabled lines

Phase 4 - Minor Optimizations:
- Pre-allocate String capacity in Line::render()

All 494 tests pass. Benchmarks show 9-13% improvement on large files.

https://claude.ai/code/session_01BChBpcWQCoyFgTSsqF9ZsC