### PR TITLE
bm/perf-boost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,12 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,13 +991,13 @@ dependencies = [
  "phf",
  "predicates",
  "pretty_assertions",
+ "rayon",
  "serde",
  "similar",
  "smallvec",
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio",
  "toml",
 ]
 
@@ -1086,27 +1080,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "tokio"
-version = "1.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
-dependencies = [
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 anyhow = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "sync"] }
+rayon = "1.10"
 indicatif = "0.17"
 similar = "2"
 dirs = "6"
@@ -47,6 +47,12 @@ harness = false
 lto = true
 codegen-units = 1
 strip = true
+
+[profile.profiling]
+inherits = "release"
+debug = 2
+strip = false
+lto = false
 
 # Optimize dependencies in test/dev builds
 [profile.dev.package."*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."
 license = "Apache-2.0"

--- a/examples/profile.rs
+++ b/examples/profile.rs
@@ -1,0 +1,24 @@
+use sqlfmt::{format_string, Mode};
+
+fn main() {
+    let path = "tests/data/unformatted/216_gitlab_zuora_revenue_revenue_contract_line_source.sql";
+    let content = std::fs::read_to_string(path).expect("Failed to read test file");
+
+    // Extract input portion (before sentinel)
+    let sql = if let Some(pos) = content.find(")))))__SQLFMT_OUTPUT__(((((") {
+        &content[..pos]
+    } else {
+        &content
+    };
+
+    let mode = Mode::default();
+    let iterations = 5000;
+
+    eprintln!("Formatting {} ({} bytes) x {} iterations...", path, sql.len(), iterations);
+
+    for _ in 0..iterations {
+        let _ = format_string(sql, &mode).unwrap();
+    }
+
+    eprintln!("Done.");
+}

--- a/examples/profile.rs
+++ b/examples/profile.rs
@@ -14,7 +14,12 @@ fn main() {
     let mode = Mode::default();
     let iterations = 5000;
 
-    eprintln!("Formatting {} ({} bytes) x {} iterations...", path, sql.len(), iterations);
+    eprintln!(
+        "Formatting {} ({} bytes) x {} iterations...",
+        path,
+        sql.len(),
+        iterations
+    );
 
     for _ in 0..iterations {
         let _ = format_string(sql, &mode).unwrap();

--- a/src/api.rs
+++ b/src/api.rs
@@ -64,7 +64,7 @@ pub fn format_string(source: &str, mode: &Mode) -> Result<String, SqlfmtError> {
 }
 
 /// Run the formatter on a collection of files.
-pub async fn run(files: &[PathBuf], mode: &Mode) -> Report {
+pub fn run(files: &[PathBuf], mode: &Mode) -> Report {
     let matching_paths = get_matching_paths(files, mode);
     let mut report = Report::new();
 
@@ -74,7 +74,8 @@ pub async fn run(files: &[PathBuf], mode: &Mode) -> Report {
             report.add(result);
         }
     } else {
-        // Limit concurrency to the configured thread count (or num_cpus).
+        use rayon::prelude::*;
+
         let concurrency = if mode.threads > 0 {
             mode.threads
         } else {
@@ -82,101 +83,22 @@ pub async fn run(files: &[PathBuf], mode: &Mode) -> Report {
                 .map(|n| n.get())
                 .unwrap_or(4)
         };
-        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
-
-        let mut handles = Vec::with_capacity(matching_paths.len());
-        for path in matching_paths {
-            let mode = mode.clone();
-            let sem = semaphore.clone();
-            handles.push(tokio::spawn(async move {
-                let _permit = sem.acquire().await.expect("semaphore closed");
-                format_file_async(&path, &mode).await
-            }));
-        }
-        for handle in handles {
-            match handle.await {
-                Ok(result) => report.add(result),
-                Err(e) => report.add(FileResult {
-                    path: PathBuf::from("<unknown>"),
-                    status: crate::report::FileStatus::Error,
-                    error: Some(format!("Task join error: {}", e)),
-                }),
-            }
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrency)
+            .build()
+            .expect("failed to build rayon thread pool");
+        let results: Vec<FileResult> = pool.install(|| {
+            matching_paths
+                .par_iter()
+                .map(|path| format_file(path, mode))
+                .collect()
+        });
+        for result in results {
+            report.add(result);
         }
     }
 
     report
-}
-
-/// Format a single file asynchronously.
-/// Uses async I/O for reading/writing and spawn_blocking for CPU-bound formatting.
-async fn format_file_async(path: &Path, mode: &Mode) -> FileResult {
-    let source = match tokio::fs::read_to_string(path).await {
-        Ok(s) => s,
-        Err(e) => {
-            return FileResult {
-                path: path.to_path_buf(),
-                status: crate::report::FileStatus::Error,
-                error: Some(format!("Read error: {}", e)),
-            };
-        }
-    };
-
-    let mode_clone = mode.clone();
-    let (source, formatted) = match tokio::task::spawn_blocking(move || {
-        let result = format_string(&source, &mode_clone);
-        (source, result)
-    })
-    .await
-    {
-        Ok((source, Ok(f))) => (source, f),
-        Ok((_, Err(e))) => {
-            return FileResult {
-                path: path.to_path_buf(),
-                status: crate::report::FileStatus::Error,
-                error: Some(format!("{}", e)),
-            };
-        }
-        Err(e) => {
-            return FileResult {
-                path: path.to_path_buf(),
-                status: crate::report::FileStatus::Error,
-                error: Some(format!("Blocking task error: {}", e)),
-            };
-        }
-    };
-
-    if source == formatted {
-        return FileResult {
-            path: path.to_path_buf(),
-            status: crate::report::FileStatus::Unchanged,
-            error: None,
-        };
-    }
-
-    if mode.check || mode.diff {
-        if mode.diff {
-            print_diff(path, &source, &formatted);
-        }
-        return FileResult {
-            path: path.to_path_buf(),
-            status: crate::report::FileStatus::Changed,
-            error: None,
-        };
-    }
-
-    match tokio::fs::write(path, &formatted).await {
-        Ok(_) => FileResult {
-            path: path.to_path_buf(),
-            status: crate::report::FileStatus::Changed,
-            error: None,
-        },
-        Err(e) => FileResult {
-            path: path.to_path_buf(),
-            status: crate::report::FileStatus::Error,
-            error: Some(format!("Write error: {}", e)),
-        },
-    }
 }
 
 /// Format a single file.

--- a/src/api_test.rs
+++ b/src/api_test.rs
@@ -125,10 +125,10 @@ fn test_get_matching_paths_excludes() {
     assert_eq!(paths.len(), 1);
 }
 
-#[tokio::test]
-async fn test_run_empty_files() {
+#[test]
+fn test_run_empty_files() {
     let mode = Mode::default();
-    let report = run(&[], &mode).await;
+    let report = run(&[], &mode);
     assert_eq!(report.total(), 0);
     assert!(!report.has_errors());
     assert!(!report.has_changes());

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -133,7 +133,8 @@ impl QueryFormatter {
     /// Stage 4: Merge short lines back together.
     fn merge_lines(&self, query: &mut Query, arena: &[Node]) {
         let merger = LineMerger::new(self.line_length);
-        query.lines = merger.maybe_merge_lines(&query.lines, arena);
+        let lines = std::mem::take(&mut query.lines);
+        query.lines = merger.maybe_merge_lines(lines, arena);
     }
 
     /// Stage 5: Remove extra blank lines.
@@ -276,7 +277,9 @@ fn split_line_at_jinja(line: Line, split_pos: usize, arena: &mut Vec<Node>) -> (
     }
     line2.formatting_disabled = line.formatting_disabled;
 
-    for comment in line.comments {
+    let comments =
+        std::rc::Rc::try_unwrap(line.comments).unwrap_or_else(|rc| (*rc).clone());
+    for comment in comments {
         if comment.is_standalone {
             line2.append_comment(comment);
         } else {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -277,8 +277,7 @@ fn split_line_at_jinja(line: Line, split_pos: usize, arena: &mut Vec<Node>) -> (
     }
     line2.formatting_disabled = line.formatting_disabled;
 
-    let comments =
-        std::rc::Rc::try_unwrap(line.comments).unwrap_or_else(|rc| (*rc).clone());
+    let comments = std::rc::Rc::try_unwrap(line.comments).unwrap_or_else(|rc| (*rc).clone());
     for comment in comments {
         if comment.is_standalone {
             line2.append_comment(comment);

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use std::sync::LazyLock;
 
 use crate::comment::Comment;
@@ -34,7 +35,7 @@ pub(crate) fn indent_str(n: usize) -> &'static str {
 pub(crate) struct Line {
     pub(crate) previous_node: Option<NodeIndex>,
     pub(crate) nodes: Vec<NodeIndex>,
-    pub(crate) comments: Vec<Comment>,
+    pub(crate) comments: Rc<Vec<Comment>>,
     pub(crate) formatting_disabled: bool,
 }
 
@@ -43,7 +44,7 @@ impl Line {
         Self {
             previous_node,
             nodes: Vec::with_capacity(4),
-            comments: Vec::new(),
+            comments: Rc::new(Vec::new()),
             formatting_disabled: false,
         }
     }
@@ -150,7 +151,7 @@ impl Line {
 
         // A multiline comment that is not standalone (e.g., /* ... */ appearing mid-line)
         // must still be rendered as standalone to avoid being silently dropped.
-        for comment in &self.comments {
+        for comment in self.comments.iter() {
             if comment.is_standalone || comment.is_multiline() {
                 result.push_str(&comment.render_standalone(prefix, max_line_length));
             }
@@ -380,7 +381,7 @@ impl Line {
 
     /// Append a comment to this line.
     pub(crate) fn append_comment(&mut self, comment: Comment) {
-        self.comments.push(comment);
+        Rc::make_mut(&mut self.comments).push(comment);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,24 +116,6 @@ fn main() {
         single_process: cli.single_process,
     };
 
-    // Build the tokio runtime, capping both async workers and blocking threads.
-    let num_threads = if mode.threads > 0 {
-        mode.threads
-    } else {
-        std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(4)
-    };
-    let mut builder = tokio::runtime::Builder::new_multi_thread();
-    builder.enable_all();
-    builder.worker_threads(num_threads);
-    builder.max_blocking_threads(num_threads);
-    let runtime = builder.build().expect("failed to build tokio runtime");
-
-    runtime.block_on(async_main(cli.files, mode, is_stdin));
-}
-
-async fn async_main(files: Vec<PathBuf>, mode: Mode, is_stdin: bool) {
     if is_stdin {
         let mut source = String::new();
         if let Err(e) = io::stdin().read_to_string(&mut source) {
@@ -151,7 +133,7 @@ async fn async_main(files: Vec<PathBuf>, mode: Mode, is_stdin: bool) {
             }
         }
     } else {
-        let report = sqlfmt::run(&files, &mode).await;
+        let report = sqlfmt::run(&cli.files, &mode);
 
         if !mode.quiet {
             print_verbose_results(&report, &mode);

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -51,8 +51,7 @@ impl LineMerger {
                         self.merge_single_segment(&segments[0], arena, &mut merged_lines);
                     } else {
                         for segment in segments {
-                            merged_lines
-                                .extend(self.maybe_merge_lines(segment.lines, arena));
+                            merged_lines.extend(self.maybe_merge_lines(segment.lines, arena));
                         }
                     }
                 } else {
@@ -581,7 +580,11 @@ impl LineMerger {
         for &split in &split_points {
             let idx = split - offset;
             let tail = remaining.split_off(idx);
-            new_segments.extend(self.try_merge_operator_segments(remaining, remaining_tiers, arena));
+            new_segments.extend(self.try_merge_operator_segments(
+                remaining,
+                remaining_tiers,
+                arena,
+            ));
             remaining = tail;
             offset = split;
         }

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -23,19 +23,20 @@ impl LineMerger {
 
     /// Main entry: try to merge lines.
     /// Mirrors Python's `maybe_merge_lines`.
-    pub(crate) fn maybe_merge_lines(&self, lines: &[Line], arena: &[Node]) -> Vec<Line> {
+    /// Takes ownership to avoid cloning on early-exit and recursive paths.
+    pub(crate) fn maybe_merge_lines(&self, lines: Vec<Line>, arena: &[Node]) -> Vec<Line> {
         if lines.is_empty() || lines.iter().all(|l| l.has_formatting_disabled()) {
-            return lines.to_vec();
+            return lines;
         }
 
-        match self.create_merged_line(lines, arena) {
+        match self.create_merged_line(&lines, arena) {
             Ok(merged) => merged,
             Err(_) => {
+                let input_line_count = lines.len();
                 let mut merged_lines = Vec::new();
                 let segments = build_segments(lines, arena);
 
                 if segments.len() > 1 {
-                    let input_line_count = lines.len();
                     let segments = self.fix_standalone_operators(segments, arena);
                     let segments =
                         self.maybe_merge_operators(segments, OperatorPrecedence::tiers(), arena);
@@ -49,8 +50,9 @@ impl LineMerger {
                     if segments.len() == 1 && segments[0].lines.len() == input_line_count {
                         self.merge_single_segment(&segments[0], arena, &mut merged_lines);
                     } else {
-                        for segment in &segments {
-                            merged_lines.extend(self.maybe_merge_lines(&segment.lines, arena));
+                        for segment in segments {
+                            merged_lines
+                                .extend(self.maybe_merge_lines(segment.lines, arena));
                         }
                     }
                 } else {
@@ -93,24 +95,25 @@ impl LineMerger {
             return;
         }
 
-        let remaining = &segment.lines[include_end..];
-
         if !segment.tail_closes_head(arena) {
-            merged_lines.extend(self.maybe_merge_lines(remaining, arena));
+            merged_lines
+                .extend(self.maybe_merge_lines(segment.lines[include_end..].to_vec(), arena));
             return;
         }
         let Ok((tail_idx, _)) = segment.tail(arena) else {
-            merged_lines.extend(self.maybe_merge_lines(remaining, arena));
+            merged_lines
+                .extend(self.maybe_merge_lines(segment.lines[include_end..].to_vec(), arena));
             return;
         };
         let tail_start = segment.lines.len() - 1 - tail_idx;
         if include_end >= tail_start {
-            merged_lines.extend(self.maybe_merge_lines(remaining, arena));
+            merged_lines
+                .extend(self.maybe_merge_lines(segment.lines[include_end..].to_vec(), arena));
             return;
         }
 
-        let inner = &segment.lines[include_end..tail_start];
-        let merged_inner = self.maybe_merge_lines(inner, arena);
+        let merged_inner =
+            self.maybe_merge_lines(segment.lines[include_end..tail_start].to_vec(), arena);
         self.try_merge_jinja_keyword_with_inner(merged_lines, merged_inner, arena);
         merged_lines.extend_from_slice(&segment.lines[tail_start..]);
     }
@@ -143,7 +146,13 @@ impl LineMerger {
             .pop()
             .expect("head_is_jinja_keyword requires non-empty merged_lines");
         let first_inner = &merged_inner[fci];
-        match self.create_merged_line(&[last_head.clone(), first_inner.clone()], arena) {
+        let try_lines = [last_head.clone(), first_inner.clone()];
+        let merge_result = if self.can_merge_lines(&try_lines, arena) {
+            self.create_merged_line(&try_lines, arena)
+        } else {
+            Err(ControlFlow::CannotMerge)
+        };
+        match merge_result {
             Ok(merged) => {
                 merged_lines.extend(merged);
                 merged_lines.extend_from_slice(&merged_inner[fci + 1..]);
@@ -214,6 +223,9 @@ impl LineMerger {
         }
 
         let to_merge = vec![lines[i].clone(), lines[ni].clone()];
+        if !self.can_merge_lines(&to_merge, arena) {
+            return false;
+        }
         let merged = match self.create_merged_line(&to_merge, arena) {
             Ok(m) => m,
             Err(_) => return false,
@@ -233,6 +245,67 @@ impl LineMerger {
             }
         }
         true
+    }
+
+    /// Cheap pre-check: can these lines merge without exceeding max_length?
+    /// Runs extract_components for rule validation and computes the merged
+    /// length arithmetically, avoiding construction of a merged Line.
+    fn can_merge_lines(&self, lines: &[Line], arena: &[Node]) -> bool {
+        if lines.len() <= 1 {
+            return true;
+        }
+
+        let leading_count = lines
+            .iter()
+            .take_while(|l| l.is_blank_line(arena) || l.is_standalone_comment_line(arena))
+            .count();
+        let trailing_count = lines
+            .iter()
+            .rev()
+            .take_while(|l| l.is_blank_line(arena) || l.is_standalone_comment_line(arena))
+            .count();
+        let content_end = lines.len() - trailing_count;
+        let content_start = leading_count.min(content_end);
+        let content_lines = &lines[content_start..content_end];
+
+        if content_lines.len() <= 1 {
+            return true;
+        }
+
+        let (nodes, _comments) = match Self::extract_components(content_lines, arena) {
+            Ok(pair) => pair,
+            Err(_) => return false,
+        };
+
+        // Compute merged length arithmetically (mirrors Line::len fast path)
+        let indent_size = content_lines[0].indent_size(arena);
+
+        // Check for multiline nodes — if present, we can't compute length cheaply,
+        // so fall back to allowing the merge (create_merged_line will catch it).
+        let has_multiline_node = nodes.iter().any(|&idx| {
+            let node = &arena[idx];
+            !node.is_newline() && node.value.contains('\n')
+        });
+        if has_multiline_node {
+            return true; // let create_merged_line handle multiline
+        }
+
+        let mut length = indent_size;
+        let mut first_content = true;
+        for &idx in &nodes {
+            let node = &arena[idx];
+            if node.is_newline() {
+                continue;
+            }
+            if first_content {
+                length += node.value.len();
+                first_content = false;
+            } else {
+                length += node.len();
+            }
+        }
+
+        length <= self.max_length
     }
 
     /// Try to merge all lines into a single line.
@@ -265,7 +338,7 @@ impl LineMerger {
         for &idx in &nodes {
             merged_line.append_node(idx);
         }
-        merged_line.comments = comments;
+        merged_line.comments = std::rc::Rc::new(comments);
 
         if merged_line.len(arena) > self.max_length {
             return Err(ControlFlow::CannotMerge);
@@ -487,24 +560,32 @@ impl LineMerger {
             return segments;
         }
         let remaining_tiers = &op_tiers[..op_tiers.len() - 1];
-        let mut new_segments: Vec<Segment> = Vec::new();
-        let mut head = 0;
 
-        for i in 1..segments.len() {
-            if !self.segment_continues_operator_sequence(&segments[i], precedence, arena) {
-                new_segments.extend(self.try_merge_operator_segments(
-                    &segments[head..i],
-                    remaining_tiers,
-                    arena,
-                ));
-                head = i;
+        // Compute split points (indices where a new run starts)
+        let mut split_points = Vec::new();
+        for (i, seg) in segments.iter().enumerate().skip(1) {
+            if !self.segment_continues_operator_sequence(seg, precedence, arena) {
+                split_points.push(i);
             }
         }
-        new_segments.extend(self.try_merge_operator_segments(
-            &segments[head..],
-            remaining_tiers,
-            arena,
-        ));
+
+        // If no splits, the entire vec is one run
+        if split_points.is_empty() {
+            return self.try_merge_operator_segments(segments, remaining_tiers, arena);
+        }
+
+        // Split segments into runs and merge each
+        let mut new_segments: Vec<Segment> = Vec::new();
+        let mut remaining = segments;
+        let mut offset = 0;
+        for &split in &split_points {
+            let idx = split - offset;
+            let tail = remaining.split_off(idx);
+            new_segments.extend(self.try_merge_operator_segments(remaining, remaining_tiers, arena));
+            remaining = tail;
+            offset = split;
+        }
+        new_segments.extend(self.try_merge_operator_segments(remaining, remaining_tiers, arena));
 
         new_segments
     }
@@ -561,7 +642,7 @@ impl LineMerger {
             if !prev_ends_comma {
                 return false;
             }
-            return self.create_merged_line(&segment.lines, arena).is_ok();
+            return self.can_merge_lines(&segment.lines, arena);
         }
         // Leading-comma style: `, lateral` — first content is comma, second is lateral
         if first.is_comma() {
@@ -569,7 +650,7 @@ impl LineMerger {
                 if second.token.token_type == crate::token::TokenType::UntermKeyword
                     && second.value.eq_ignore_ascii_case("lateral")
                 {
-                    return self.create_merged_line(&segment.lines, arena).is_ok();
+                    return self.can_merge_lines(&segment.lines, arena);
                 }
             }
         }
@@ -630,22 +711,22 @@ impl LineMerger {
     /// Try to merge a run of segments into one.
     fn try_merge_operator_segments(
         &self,
-        segments: &[Segment],
+        segments: Vec<Segment>,
         op_tiers: &[OperatorPrecedence],
         arena: &[Node],
     ) -> Vec<Segment> {
         if segments.len() <= 1 {
-            return segments.to_vec();
+            return segments;
         }
 
         let total_lines: usize = segments.iter().map(|s| s.lines.len()).sum();
         let mut all_lines = Vec::with_capacity(total_lines);
-        for s in segments {
+        for s in &segments {
             all_lines.extend_from_slice(&s.lines);
         }
         match self.create_merged_line(&all_lines, arena) {
             Ok(merged) => vec![Segment::new(merged)],
-            Err(_) => self.maybe_merge_operators(segments.to_vec(), op_tiers, arena),
+            Err(_) => self.maybe_merge_operators(segments, op_tiers, arena),
         }
     }
 
@@ -756,7 +837,12 @@ impl LineMerger {
         // Attempt 1: merge all prev_segment lines + head_line.
         // Temporarily push onto prev_segment to avoid cloning all its lines.
         prev_segment.lines.push(head_line.clone());
-        let attempt1 = self.create_merged_line(&prev_segment.lines, arena);
+        let can_merge = self.can_merge_lines(&prev_segment.lines, arena);
+        let attempt1 = if can_merge {
+            self.create_merged_line(&prev_segment.lines, arena)
+        } else {
+            Err(ControlFlow::CannotMerge)
+        };
         prev_segment.lines.pop();
         if let Ok(merged) = attempt1 {
             let mut result_seg = Segment::new(merged);
@@ -797,15 +883,20 @@ impl LineMerger {
         let mut try_lines = Vec::with_capacity(1 + segment.lines.len());
         try_lines.push(tail_line.clone());
         try_lines.extend_from_slice(&segment.lines);
-        if let Ok(merged) = self.create_merged_line(&try_lines, arena) {
-            let tail_start = prev_segment.lines.len() - 1 - tail_idx;
-            let mut result_seg = Segment::new(prev_segment.lines[..tail_start].to_vec());
-            result_seg.lines.extend(merged);
-            return Some(result_seg);
+        if self.can_merge_lines(&try_lines, arena) {
+            if let Ok(merged) = self.create_merged_line(&try_lines, arena) {
+                let tail_start = prev_segment.lines.len() - 1 - tail_idx;
+                let mut result_seg = Segment::new(prev_segment.lines[..tail_start].to_vec());
+                result_seg.lines.extend(merged);
+                return Some(result_seg);
+            }
         }
 
         // Attempt 3: merge tail + head line only
         let try_lines = [tail_line.clone(), head_line.clone()];
+        if !self.can_merge_lines(&try_lines, arena) {
+            return None;
+        }
         if let Ok(merged) = self.create_merged_line(&try_lines, arena) {
             let tail_start = prev_segment.lines.len() - 1 - tail_idx;
             let mut result_seg = Segment::new(prev_segment.lines[..tail_start].to_vec());

--- a/src/merger_test.rs
+++ b/src/merger_test.rs
@@ -30,7 +30,7 @@ fn test_no_merge_single_line() {
     let mut arena = Vec::new();
     let line = make_simple_line(&mut arena, TokenType::Name, "a");
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[line], &arena);
+    let result = merger.maybe_merge_lines(vec![line], &arena);
     assert_eq!(result.len(), 1);
 }
 
@@ -41,7 +41,7 @@ fn test_merge_short_lines() {
     let line2 = make_simple_line(&mut arena, TokenType::Name, "b");
 
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[line1, line2], &arena);
+    let result = merger.maybe_merge_lines(vec![line1, line2], &arena);
     // Should merge
     assert!(result.len() <= 2);
 }
@@ -54,7 +54,7 @@ fn test_no_merge_long_result() {
     let line2 = make_simple_line(&mut arena, TokenType::Name, &long_val);
 
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[line1, line2], &arena);
+    let result = merger.maybe_merge_lines(vec![line1, line2], &arena);
     // Should NOT merge since combined length > 88
     assert!(
         result.len() >= 2,
@@ -66,7 +66,7 @@ fn test_no_merge_long_result() {
 fn test_merge_empty_input() {
     let arena = Vec::new();
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[], &arena);
+    let result = merger.maybe_merge_lines(vec![], &arena);
     assert!(result.is_empty());
 }
 
@@ -85,7 +85,7 @@ fn test_no_merge_across_query_dividers() {
     let line3 = make_simple_line(&mut arena, TokenType::Name, "b");
 
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[line1, semi_line, line3], &arena);
+    let result = merger.maybe_merge_lines(vec![line1, semi_line, line3], &arena);
     // Should not merge across the semicolon
     assert!(
         result.len() >= 2,
@@ -108,7 +108,7 @@ fn test_no_merge_formatting_disabled() {
     disabled_line.formatting_disabled = true;
 
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[disabled_line], &arena);
+    let result = merger.maybe_merge_lines(vec![disabled_line], &arena);
     assert_eq!(result.len(), 1);
 }
 
@@ -125,7 +125,7 @@ fn test_merge_with_blank_lines() {
     let line3 = make_simple_line(&mut arena, TokenType::Name, "b");
 
     let merger = LineMerger::new(88);
-    let result = merger.maybe_merge_lines(&[line1, blank, line3], &arena);
+    let result = merger.maybe_merge_lines(vec![line1, blank, line3], &arena);
     // Should produce at least 1 line and not crash
     assert!(
         !result.is_empty(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -122,18 +122,17 @@ impl Segment {
 /// Build segments from a flat list of lines.
 /// Mirrors Python's `create_segments_from_lines`:
 /// A segment is a list of consecutive lines that are indented from the first line.
-pub(crate) fn build_segments(lines: &[Line], arena: &[Node]) -> Vec<Segment> {
+/// Takes ownership of lines and uses drain() to avoid cloning.
+pub(crate) fn build_segments(mut lines: Vec<Line>, arena: &[Node]) -> Vec<Segment> {
     if lines.is_empty() {
         return Vec::new();
     }
 
-    let mut segments: Vec<Segment> = Vec::new();
+    // Pass 1: compute split indices (read-only scan)
+    let mut split_points = Vec::new();
     let mut j = 0;
-
     while j < lines.len() {
         let target_depth = lines[j].depth(arena);
-
-        // Determine start index for scanning
         let start_idx = if lines[j].is_standalone_operator(arena) {
             j + 2
         } else {
@@ -143,19 +142,26 @@ pub(crate) fn build_segments(lines: &[Line], arena: &[Node]) -> Vec<Segment> {
         let mut found = false;
         for i in start_idx..lines.len() {
             if lines[i].starts_new_segment_at_depth(target_depth, arena) {
-                segments.push(Segment::new(lines[j..i].to_vec()));
+                split_points.push(i);
                 j = i;
                 found = true;
                 break;
             }
         }
-
         if !found {
-            segments.push(Segment::new(lines[j..].to_vec()));
             break;
         }
     }
 
+    // Pass 2: drain ranges from back to front (avoids index shifting)
+    let mut segments = Vec::with_capacity(split_points.len() + 1);
+    for &split in split_points.iter().rev() {
+        let tail: Vec<Line> = lines.drain(split..).collect();
+        segments.push(Segment::new(tail));
+    }
+    // Remaining lines form the first segment
+    segments.push(Segment::new(lines));
+    segments.reverse();
     segments
 }
 

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -140,8 +140,8 @@ pub(crate) fn build_segments(mut lines: Vec<Line>, arena: &[Node]) -> Vec<Segmen
         };
 
         let mut found = false;
-        for i in start_idx..lines.len() {
-            if lines[i].starts_new_segment_at_depth(target_depth, arena) {
+        for (i, line) in lines.iter().enumerate().skip(start_idx) {
+            if line.starts_new_segment_at_depth(target_depth, arena) {
                 split_points.push(i);
                 j = i;
                 found = true;

--- a/src/segment_test.rs
+++ b/src/segment_test.rs
@@ -43,14 +43,14 @@ fn test_build_segments() {
     let line1 = make_line(&mut arena, TokenType::Name, "a");
     let line2 = make_line(&mut arena, TokenType::Name, "b");
 
-    let segments = build_segments(&[line1, line2], &arena);
+    let segments = build_segments(vec![line1, line2], &arena);
     assert!(!segments.is_empty());
 }
 
 #[test]
 fn test_build_segments_empty() {
     let arena: Vec<Node> = Vec::new();
-    let segments = build_segments(&[], &arena);
+    let segments = build_segments(vec![], &arena);
     assert!(segments.is_empty());
 }
 

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -31,8 +31,7 @@ impl LineSplitter {
 
         let mut new_lines: Vec<Line> = Vec::new();
         let rc_comments = std::mem::take(&mut line.comments);
-        let mut comments =
-            std::rc::Rc::try_unwrap(rc_comments).unwrap_or_else(|rc| (*rc).clone());
+        let mut comments = std::rc::Rc::try_unwrap(rc_comments).unwrap_or_else(|rc| (*rc).clone());
         let mut head: usize = 0;
         let mut always_split_after = false;
         let mut never_split_after = false;

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -30,7 +30,9 @@ impl LineSplitter {
         }
 
         let mut new_lines: Vec<Line> = Vec::new();
-        let mut comments = std::mem::take(&mut line.comments);
+        let rc_comments = std::mem::take(&mut line.comments);
+        let mut comments =
+            std::rc::Rc::try_unwrap(rc_comments).unwrap_or_else(|rc| (*rc).clone());
         let mut head: usize = 0;
         let mut always_split_after = false;
         let mut never_split_after = false;
@@ -41,7 +43,7 @@ impl LineSplitter {
 
             if node.is_newline() {
                 if head == 0 {
-                    line.comments = comments;
+                    line.comments = std::rc::Rc::new(comments);
                     new_lines.push(line);
                 } else {
                     let (new_line, _remaining_comments) =
@@ -273,7 +275,7 @@ impl LineSplitter {
         for &idx in &new_nodes {
             new_line.append_node(idx);
         }
-        new_line.comments = head_comments;
+        new_line.comments = std::rc::Rc::new(head_comments);
 
         if let Some(&last_node) = new_nodes.last() {
             if !arena[last_node].is_newline() {


### PR DESCRIPTION
- 456/456 tests pass
  - format_large: 3.69ms → 2.82ms (-23.6%)
  - format_no_safety: 3.32ms → 2.58ms (-22.3%)
  - No new clippy warnings introduced