### PR TITLE
Fix Jinja quote normalization to preserve nested quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -319,7 +319,7 @@ fn normalize_token_text(text: &str, token_type: crate::token::TokenType) -> Stri
                 .trim_end_matches("-}}")
                 .trim_end_matches("}}");
             let normalized = join_whitespace(inner);
-            let normalized = normalized.replace('\'', "\"");
+            let normalized = normalize_jinja_quotes(&normalized);
             let normalized = normalize_jinja_operators(&normalized);
             let normalized = normalize_jinja_structure(&normalized);
             format!("{{{{ {} }}}}", normalized)
@@ -334,13 +334,82 @@ fn normalize_token_text(text: &str, token_type: crate::token::TokenType) -> Stri
                 .trim_end_matches("-%}")
                 .trim_end_matches("%}");
             let normalized = join_whitespace(inner);
-            let normalized = normalized.replace('\'', "\"");
+            let normalized = normalize_jinja_quotes(&normalized);
             let normalized = normalize_jinja_operators(&normalized);
             let normalized = normalize_jinja_structure(&normalized);
             format!("{{% {} %}}", normalized)
         }
         _ => join_whitespace(text),
     }
+}
+
+/// Normalize single-quoted string delimiters to double quotes for equivalence,
+/// without modifying single quotes that appear inside double-quoted strings.
+/// E.g. `'hello'` → `"hello"`, but `"'csnp', 'dual'"` stays unchanged.
+fn normalize_jinja_quotes(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            // Already a double-quoted string — copy it verbatim
+            result.push('"');
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    result.push(bytes[i] as char);
+                    result.push(bytes[i + 1] as char);
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    // Check for doubled-quote escape ""
+                    if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+                        result.push('"');
+                        result.push('"');
+                        i += 2;
+                        continue;
+                    }
+                    result.push('"');
+                    i += 1;
+                    break;
+                }
+                result.push(bytes[i] as char);
+                i += 1;
+            }
+        } else if bytes[i] == b'\'' {
+            // Single-quoted string delimiter — convert to double quote
+            result.push('"');
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    result.push(bytes[i] as char);
+                    result.push(bytes[i + 1] as char);
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'\'' {
+                    // Check for doubled-quote escape ''
+                    if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                        result.push('\'');
+                        result.push('\'');
+                        i += 2;
+                        continue;
+                    }
+                    result.push('"');
+                    i += 1;
+                    break;
+                }
+                result.push(bytes[i] as char);
+                i += 1;
+            }
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    result
 }
 
 /// Normalize structural characters in Jinja content for equivalence.
@@ -401,8 +470,11 @@ fn normalize_jinja_structure(text: &str) -> String {
             continue;
         }
 
-        // After comma, normalize to exactly no space (we strip all optional spaces)
+        // Around comma, normalize spacing (strip spaces before and after)
         if bytes[i] == b',' {
+            // Remove trailing whitespace before comma
+            let trimmed = result.trim_end().len();
+            result.truncate(trimmed);
             result.push(',');
             i += 1;
             // Skip spaces after comma

--- a/src/api_test.rs
+++ b/src/api_test.rs
@@ -141,3 +141,50 @@ fn test_normalize_jinja_operators() {
     let b = normalize_jinja_operators("a + b");
     assert_eq!(a, b, "Operator spacing should be normalized identically");
 }
+
+#[test]
+fn test_normalize_jinja_quotes_simple() {
+    let result = normalize_jinja_quotes("'hello'");
+    assert_eq!(result, "\"hello\"");
+}
+
+#[test]
+fn test_normalize_jinja_quotes_preserves_singles_inside_doubles() {
+    // Single quotes inside double-quoted strings must not be converted
+    let input = r#"include_types="'type_a', 'type_b'""#;
+    let result = normalize_jinja_quotes(input);
+    assert_eq!(result, input, "Single quotes inside double-quoted strings should be preserved");
+}
+
+#[test]
+fn test_normalize_jinja_quotes_mixed() {
+    let input = r#"rollup_flag='group_rollup', include_types="'type_a', 'type_b'""#;
+    let result = normalize_jinja_quotes(input);
+    assert_eq!(
+        result,
+        r#"rollup_flag="group_rollup", include_types="'type_a', 'type_b'""#
+    );
+}
+
+#[test]
+fn test_equivalence_dbt_config_nested_quotes() {
+    // This was the failing case: a Jinja expression with single quotes
+    // inside double-quoted string values should pass the safety check.
+    let mode = Mode::default();
+    let source = r#"{{ measures_rollup(rollup_flag="group_rollup", include_types="'type_a', 'type_b'") }}
+"#;
+    let result = format_string(source, &mode);
+    assert!(
+        result.is_ok(),
+        "Jinja with nested quotes should pass safety check: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_normalize_jinja_structure_comma_spacing() {
+    // Spaces before commas should be stripped
+    let a = normalize_jinja_structure(r#""value" , next"#);
+    let b = normalize_jinja_structure(r#""value", next"#);
+    assert_eq!(a, b, "Spaces before commas should be normalized");
+}

--- a/src/api_test.rs
+++ b/src/api_test.rs
@@ -153,7 +153,10 @@ fn test_normalize_jinja_quotes_preserves_singles_inside_doubles() {
     // Single quotes inside double-quoted strings must not be converted
     let input = r#"include_types="'type_a', 'type_b'""#;
     let result = normalize_jinja_quotes(input);
-    assert_eq!(result, input, "Single quotes inside double-quoted strings should be preserved");
+    assert_eq!(
+        result, input,
+        "Single quotes inside double-quoted strings should be preserved"
+    );
 }
 
 #[test]

--- a/tests/data/unformatted/223_dbt_config_nested_quotes.sql
+++ b/tests/data/unformatted/223_dbt_config_nested_quotes.sql
@@ -1,0 +1,30 @@
+{{
+       config(
+              materialized="table",
+                tags=[
+                     'example_tag'
+                   ],
+              meta={
+                     'final_schema':'analytics'
+              }
+)
+}}
+{{ measures_rollup(rollup_flag="group_rollup" , include_plan_types="'type_a', 'type_b'") }}
+)))))__SQLFMT_OUTPUT__(((((
+{{
+       config(
+              materialized="table",
+                tags=[
+                     'example_tag'
+                   ],
+              meta={
+                     'final_schema':'analytics'
+              }
+)
+}}
+{{
+    measures_rollup(
+        rollup_flag="group_rollup",
+        include_plan_types="'type_a', 'type_b'",
+    )
+}}

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -114,6 +114,7 @@ golden_tests! {
     golden_unformatted_221_dbt_config_dollar_quoted => (default_mode, "tests/data/unformatted/221_dbt_config_dollar_quoted.sql"),
     golden_unformatted_222_colorado_claims_extract => (default_mode, "tests/data/unformatted/222_colorado_claims_extract.sql"),
     golden_unformatted_222_jinja_unbalanced_brackets => (default_mode, "tests/data/unformatted/222_jinja_unbalanced_brackets.sql"),
+    golden_unformatted_223_dbt_config_nested_quotes => (default_mode, "tests/data/unformatted/223_dbt_config_nested_quotes.sql"),
 
     // =========================================================================
     // Unformatted 300-series — Jinja formatting


### PR DESCRIPTION
## Summary
This PR fixes a bug in Jinja template quote normalization that was incorrectly converting single quotes inside double-quoted strings, causing false safety check failures. The fix introduces a context-aware quote normalization function that only converts top-level single-quoted strings while preserving single quotes that appear within double-quoted strings.

## Key Changes
- **New `normalize_jinja_quotes()` function**: Replaces the naive `replace('\'', "\"")` with a state-machine based parser that:
  - Converts top-level single-quoted strings to double quotes (e.g., `'hello'` → `"hello"`)
  - Preserves single quotes inside double-quoted strings (e.g., `"'type_a', 'type_b'"` remains unchanged)
  - Handles escape sequences and doubled-quote escapes correctly
  
- **Updated quote normalization calls**: Both Jinja variable (`{{ }}`) and statement (`{% %}`) token normalization now use the new function instead of simple character replacement

- **Improved comma spacing normalization**: Added logic to strip trailing whitespace before commas in `normalize_jinja_structure()` for consistent formatting

- **Comprehensive test coverage**: Added unit tests for:
  - Simple quote conversion
  - Preservation of nested quotes
  - Mixed quote scenarios
  - End-to-end formatting with nested quotes
  - Comma spacing normalization

## Notable Implementation Details
- The implementation uses byte-level parsing for efficiency and to handle escape sequences properly
- Handles both backslash escapes (`\"`, `\'`) and doubled-quote escapes (`""`, `''`)
- Maintains string capacity pre-allocation for performance
- Includes a golden test case (`223_dbt_config_nested_quotes.sql`) demonstrating the fix for dbt config with nested quotes

https://claude.ai/code/session_015ecDwLkWKnHWRakV2MXiXp