### PR TITLE
Fix quote normalization to preserve single quotes with nested double quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -379,8 +379,30 @@ fn normalize_jinja_quotes(text: &str) -> String {
                 i += 1;
             }
         } else if bytes[i] == b'\'' {
-            // Single-quoted string delimiter — convert to double quote
-            result.push('"');
+            // Single-quoted string — check if it contains unescaped double quotes.
+            // If so, keep single quotes to avoid producing ambiguous output that
+            // confuses subsequent normalization passes.
+            let mut has_double_quote = false;
+            let mut j = i + 1;
+            while j < bytes.len() {
+                if bytes[j] == b'\\' && j + 1 < bytes.len() {
+                    j += 2;
+                    continue;
+                }
+                if bytes[j] == b'\'' {
+                    if j + 1 < bytes.len() && bytes[j + 1] == b'\'' {
+                        j += 2;
+                        continue;
+                    }
+                    break;
+                }
+                if bytes[j] == b'"' {
+                    has_double_quote = true;
+                }
+                j += 1;
+            }
+            let out_quote = if has_double_quote { '\'' } else { '"' };
+            result.push(out_quote);
             i += 1;
             while i < bytes.len() {
                 if bytes[i] == b'\\' && i + 1 < bytes.len() {
@@ -397,7 +419,7 @@ fn normalize_jinja_quotes(text: &str) -> String {
                         i += 2;
                         continue;
                     }
-                    result.push('"');
+                    result.push(out_quote);
                     i += 1;
                     break;
                 }

--- a/tests/data/unformatted/224_dbt_config_unique_key_nested_quotes.sql
+++ b/tests/data/unformatted/224_dbt_config_unique_key_nested_quotes.sql
@@ -1,0 +1,26 @@
+{{
+       config(
+              materialized='incremental',
+              incremental_strategy='append',
+              on_schema_change='append_new_columns',
+              unique_key='"report_date"||"IFNULL(group_id,\'\')||"line_of_business"||"category"||COALESCE("label",group_id)"'
+       )
+}}
+SELECT current_timestamp AS etl_at
+     , *
+  FROM {{ ref('stg_daily_summary') }}
+ WHERE group_id IS NOT NULL
+)))))__SQLFMT_OUTPUT__(((((
+{{
+    config(
+        materialized="incremental",
+        incremental_strategy="append",
+        on_schema_change="append_new_columns",
+        unique_key='"report_date"||"IFNULL(group_id,\'\')||"line_of_business"||"category"||COALESCE("label",group_id)"',
+    )
+}}
+select
+    current_timestamp as etl_at
+    , *
+from {{ ref("stg_daily_summary") }}
+where group_id is not null

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -115,6 +115,7 @@ golden_tests! {
     golden_unformatted_222_colorado_claims_extract => (default_mode, "tests/data/unformatted/222_colorado_claims_extract.sql"),
     golden_unformatted_222_jinja_unbalanced_brackets => (default_mode, "tests/data/unformatted/222_jinja_unbalanced_brackets.sql"),
     golden_unformatted_223_dbt_config_nested_quotes => (default_mode, "tests/data/unformatted/223_dbt_config_nested_quotes.sql"),
+    golden_unformatted_224_dbt_config_unique_key_nested_quotes => (default_mode, "tests/data/unformatted/224_dbt_config_unique_key_nested_quotes.sql"),
 
     // =========================================================================
     // Unformatted 300-series — Jinja formatting


### PR DESCRIPTION
## Summary
This PR fixes a bug in the Jinja quote normalization logic where single-quoted strings containing unescaped double quotes were being converted to double quotes, resulting in ambiguous output that could confuse subsequent normalization passes.

## Key Changes
- **Enhanced `normalize_jinja_quotes` function**: Added logic to detect when a single-quoted string contains unescaped double quotes. When detected, the string is kept in single quotes instead of being converted to double quotes, preventing ambiguous output.
- **Implementation details**: 
  - Scans ahead within single-quoted strings to check for the presence of unescaped double quotes
  - Properly handles escaped characters (backslash escapes) and doubled single quotes (Jinja/SQL escape syntax)
  - Uses a conditional to select the appropriate output quote character based on the presence of nested double quotes
- **Test coverage**: Added test case `224_dbt_config_unique_key_nested_quotes.sql` demonstrating the fix with a complex dbt config containing a `unique_key` parameter with nested quotes
- **Version bump**: Updated version from 0.4.1 to 0.4.2

## Notable Implementation Details
The fix properly handles multiple quote escaping mechanisms:
- Backslash escapes (`\\`)
- Doubled single quotes (`''`) used in SQL/Jinja
- Distinguishes between quote delimiters and content within strings

https://claude.ai/code/session_01CdKe2qQ35CGxsg96aoqSc4