### PR TITLE
Cache operator classification on Node to eliminate repeated arena walks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/src/line.rs
+++ b/src/line.rs
@@ -270,7 +270,7 @@ impl Line {
 
     pub(crate) fn starts_with_operator(&self, arena: &[Node]) -> bool {
         self.first_content_node(arena)
-            .map(|n| n.is_operator(arena))
+            .map(|n| n.is_operator)
             .unwrap_or(false)
     }
 
@@ -311,7 +311,7 @@ impl Line {
     /// True if first node is a bracket operator.
     pub(crate) fn starts_with_bracket_operator(&self, arena: &[Node]) -> bool {
         self.first_content_node(arena)
-            .map(|n| n.is_bracket_operator(arena))
+            .map(|n| n.is_bracket_operator)
             .unwrap_or(false)
     }
 

--- a/src/line_test.rs
+++ b/src/line_test.rs
@@ -9,14 +9,20 @@ fn make_node_in_arena(
 ) -> NodeIndex {
     let idx = arena.len();
     let prev = if idx > 0 { Some(idx - 1) } else { None };
-    arena.push(Node::new(
+    let mut node = Node::new(
         Token::new(token_type, "", value, 0, value.len() as u32),
         prev,
         compact_str::CompactString::from(prefix),
         compact_str::CompactString::from(value),
         0,
         0,
-    ));
+    );
+    node.is_bracket_operator = node.compute_is_bracket_operator(arena);
+    node.is_multiplication_star = node.compute_is_multiplication_star(arena);
+    node.is_operator = node.token.token_type.is_always_operator()
+        || node.is_multiplication_star
+        || node.is_bracket_operator;
+    arena.push(node);
     idx
 }
 

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -90,7 +90,7 @@ impl LineMerger {
             && head_idx == 0
             && segment.lines[0]
                 .first_content_node(arena)
-                .map(|n| n.is_operator(arena) && !n.is_bracket_operator(arena))
+                .map(|n| n.is_operator && !n.is_bracket_operator)
                 .unwrap_or(false)
         {
             (head_idx + 2).min(segment.lines.len())
@@ -474,45 +474,20 @@ impl LineMerger {
 
             // --- Node extraction with merge rule validation ---
             if has_multiline_jinja {
-                let starts_with_op = first_content.map(|n| n.is_operator(arena)).unwrap_or(false);
+                let starts_with_op = first_content.map(|n| n.is_operator).unwrap_or(false);
                 let starts_with_comma = first_content.map(|n| n.is_comma()).unwrap_or(false);
                 if !starts_with_op && !starts_with_comma {
                     return Err(ControlFlow::CannotMerge);
                 }
-                let current_has_multiline = line
-                    .nodes
-                    .iter()
-                    .any(|&idx| arena[idx].is_multiline_jinja());
-                if current_has_multiline {
-                    return Err(ControlFlow::CannotMerge);
-                }
             }
 
-            if !nodes.is_empty() && !has_multiline_jinja {
-                let current_has_multiline = line
-                    .nodes
-                    .iter()
-                    .any(|&idx| arena[idx].is_multiline_jinja());
-                if current_has_multiline {
-                    return Err(ControlFlow::CannotMerge);
-                }
-            }
-
-            if !nodes.is_empty() {
+            let had_prior_nodes = !nodes.is_empty();
+            if had_prior_nodes {
                 if let Some(first) = first_content {
                     if first.token.token_type == crate::token::TokenType::JinjaBlockEnd
                         && jinja_block_depth <= 0
                     {
                         return Err(ControlFlow::CannotMerge);
-                    }
-                    if first.token.token_type == crate::token::TokenType::On {
-                        let line_has_multiline_jinja = line
-                            .nodes
-                            .iter()
-                            .any(|&idx| arena[idx].is_multiline_jinja());
-                        if line_has_multiline_jinja {
-                            return Err(ControlFlow::CannotMerge);
-                        }
                     }
                 }
             }
@@ -554,6 +529,13 @@ impl LineMerger {
                 }
                 nodes.push(node_idx);
             }
+            // Multiline jinja validation (deferred from pre-loop to avoid redundant scans).
+            // Only the first content line may contain multiline jinja; subsequent lines
+            // (had_prior_nodes) or lines following multiline jinja (has_multiline_jinja)
+            // are rejected.
+            if line_has_multiline && (has_multiline_jinja || had_prior_nodes) {
+                return Err(ControlFlow::CannotMerge);
+            }
             has_multiline_jinja = line_has_multiline;
             if !line.comments.is_empty() {
                 comments.extend(line.comments.iter().cloned());
@@ -578,8 +560,8 @@ impl LineMerger {
                 let is_standalone_op = head_line
                     .first_content_node(arena)
                     .map(|n| {
-                        n.is_operator(arena)
-                            && !n.is_bracket_operator(arena)
+                        n.is_operator
+                            && !n.is_bracket_operator
                             && head_line.is_standalone_content(arena)
                     })
                     .unwrap_or(false);
@@ -726,7 +708,7 @@ impl LineMerger {
         if let Some(next) = next_segment {
             if let Ok((_, next_line)) = next.head(arena) {
                 if let Some(nn) = next_line.first_content_node(arena) {
-                    if nn.is_boolean_operator() || nn.is_operator(arena) {
+                    if nn.is_boolean_operator() || nn.is_operator {
                         return false;
                     }
                 }
@@ -757,10 +739,10 @@ impl LineMerger {
                 if first.is_comma() {
                     return true;
                 }
-                first.is_operator(arena)
+                first.is_operator
                     && !line.previous_token_is_comma(arena)
                     && first.token.token_type != crate::token::TokenType::On
-                    && OperatorPrecedence::from_node(first, arena) <= max_precedence
+                    && OperatorPrecedence::from_node(first) <= max_precedence
             }
         }
     }
@@ -1035,7 +1017,7 @@ fn line_has_interior_split_points(line: &Line, arena: &[Node]) -> bool {
             continue;
         }
         // These would cause the splitter to split before them
-        if node.is_operator(arena) && !node.is_bracket_operator(arena) {
+        if node.is_operator && !node.is_bracket_operator {
             return true;
         }
         if node.is_boolean_operator() {

--- a/src/merger_test.rs
+++ b/src/merger_test.rs
@@ -5,14 +5,20 @@ use crate::token::{Token, TokenType};
 fn make_node(arena: &mut Vec<Node>, tt: TokenType, val: &str, prefix: &str) -> NodeIndex {
     let idx = arena.len();
     let prev = if idx > 0 { Some(idx - 1) } else { None };
-    arena.push(Node::new(
+    let mut node = Node::new(
         Token::new(tt, "", val, 0, val.len() as u32),
         prev,
         compact_str::CompactString::from(prefix),
         compact_str::CompactString::from(val),
         0,
         0,
-    ));
+    );
+    node.is_bracket_operator = node.compute_is_bracket_operator(arena);
+    node.is_multiplication_star = node.compute_is_multiplication_star(arena);
+    node.is_operator = node.token.token_type.is_always_operator()
+        || node.is_multiplication_star
+        || node.is_bracket_operator;
+    arena.push(node);
     idx
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,6 +24,13 @@ pub(crate) struct Node {
     pub(crate) jinja_depth: u16,
     /// Whether formatting is disabled (fmt:off region).
     pub(crate) formatting_disabled: bool,
+    /// Cached: whether this node acts as an operator in context.
+    /// Computed once at creation to avoid repeated backward arena walks.
+    pub(crate) is_operator: bool,
+    /// Cached: whether this bracket acts as an operator (e.g., array indexing).
+    pub(crate) is_bracket_operator: bool,
+    /// Cached: whether this STAR token acts as multiplication.
+    pub(crate) is_multiplication_star: bool,
 }
 
 impl Node {
@@ -43,6 +50,9 @@ impl Node {
             bracket_depth,
             jinja_depth,
             formatting_disabled: false,
+            is_operator: false,
+            is_bracket_operator: false,
+            is_multiplication_star: false,
         }
     }
 
@@ -111,8 +121,8 @@ impl Node {
 
     // --- Context-dependent classification ---
 
-    /// True if this STAR token acts as multiplication (not SELECT *).
-    pub(crate) fn is_multiplication_star(&self, arena: &[Node]) -> bool {
+    /// Compute is_multiplication_star (used during node creation to cache).
+    pub(crate) fn compute_is_multiplication_star(&self, arena: &[Node]) -> bool {
         if self.token.token_type != TokenType::Star {
             return false;
         }
@@ -129,8 +139,8 @@ impl Node {
         }
     }
 
-    /// True if this bracket acts as an operator (e.g., array indexing with `[`).
-    pub(crate) fn is_bracket_operator(&self, arena: &[Node]) -> bool {
+    /// Compute is_bracket_operator (used during node creation to cache).
+    pub(crate) fn compute_is_bracket_operator(&self, arena: &[Node]) -> bool {
         if self.token.token_type != TokenType::BracketOpen {
             return false;
         }
@@ -149,13 +159,6 @@ impl Node {
                 }
             }
         }
-    }
-
-    /// True if this node acts as an operator in context.
-    pub(crate) fn is_operator(&self, arena: &[Node]) -> bool {
-        self.token.token_type.is_always_operator()
-            || self.is_multiplication_star(arena)
-            || self.is_bracket_operator(arena)
     }
 
     /// Walk backward through previous_node links, skipping NEWLINE and

--- a/src/node_manager.rs
+++ b/src/node_manager.rs
@@ -68,7 +68,7 @@ impl NodeManager {
             )
         };
 
-        Node {
+        let mut node = Node {
             token,
             previous_node,
             prefix,
@@ -76,7 +76,17 @@ impl NodeManager {
             bracket_depth,
             jinja_depth,
             formatting_disabled,
-        }
+            is_operator: false,
+            is_bracket_operator: false,
+            is_multiplication_star: false,
+        };
+        // Cache operator classification to avoid repeated backward arena walks during merging.
+        node.is_bracket_operator = node.compute_is_bracket_operator(arena);
+        node.is_multiplication_star = node.compute_is_multiplication_star(arena);
+        node.is_operator = node.token.token_type.is_always_operator()
+            || node.is_multiplication_star
+            || node.is_bracket_operator;
+        node
     }
 
     /// Compute the bracket and jinja depths for a new node.
@@ -294,9 +304,7 @@ impl NodeManager {
         // *REPLACE and *EXCLUDE are handled by the star_replace_exclude rule
         if tt == TokenType::Name && prev_type == Some(TokenType::Star) {
             if let Some(prev_node) = prev {
-                if !prev_node.is_multiplication_star(arena)
-                    && token.text.eq_ignore_ascii_case("columns")
-                {
+                if !prev_node.is_multiplication_star && token.text.eq_ignore_ascii_case("columns") {
                     return Cow::Borrowed("");
                 }
             }

--- a/src/node_test.rs
+++ b/src/node_test.rs
@@ -33,13 +33,13 @@ fn test_is_multiplication_star() {
     arena.push(make_node(TokenType::Name, "a", None));
     let mut star = make_node(TokenType::Star, "*", Some(0));
     star.token = Token::new(TokenType::Star, "", "*", 2, 3);
-    assert!(star.is_multiplication_star(&arena));
+    assert!(star.compute_is_multiplication_star(&arena));
 
     // Star after SELECT => not multiplication
     let mut arena2 = Vec::new();
     arena2.push(make_node(TokenType::UntermKeyword, "select", None));
     let star2 = make_node(TokenType::Star, "*", Some(0));
-    assert!(!star2.is_multiplication_star(&arena2));
+    assert!(!star2.compute_is_multiplication_star(&arena2));
 }
 
 #[test]
@@ -76,27 +76,27 @@ fn test_is_square_bracket_operator() {
     arena.push(make_node(TokenType::Name, "arr", None));
     let mut bracket = make_node(TokenType::BracketOpen, "[", Some(0));
     bracket.value = CompactString::from("[");
-    assert!(bracket.is_bracket_operator(&arena));
+    assert!(bracket.compute_is_bracket_operator(&arena));
 
     // Square bracket after QuotedName => bracket operator
     let mut arena2 = Vec::new();
     arena2.push(make_node(TokenType::QuotedName, "\"my_col\"", None));
     let mut bracket2 = make_node(TokenType::BracketOpen, "[", Some(0));
     bracket2.value = CompactString::from("[");
-    assert!(bracket2.is_bracket_operator(&arena2));
+    assert!(bracket2.compute_is_bracket_operator(&arena2));
 
     // Square bracket after BracketClose => bracket operator
     let mut arena3 = Vec::new();
     arena3.push(make_node(TokenType::BracketClose, "]", None));
     let mut bracket3 = make_node(TokenType::BracketOpen, "[", Some(0));
     bracket3.value = CompactString::from("[");
-    assert!(bracket3.is_bracket_operator(&arena3));
+    assert!(bracket3.compute_is_bracket_operator(&arena3));
 
     // Square bracket with no previous node => NOT bracket operator
     let arena4: Vec<Node> = Vec::new();
     let mut bracket4 = make_node(TokenType::BracketOpen, "[", None);
     bracket4.value = CompactString::from("[");
-    assert!(!bracket4.is_bracket_operator(&arena4));
+    assert!(!bracket4.compute_is_bracket_operator(&arena4));
 }
 
 #[test]
@@ -125,15 +125,27 @@ fn test_is_operator_context() {
     // A WordOperator is always an operator
     let arena: Vec<Node> = Vec::new();
     let node = make_node(TokenType::WordOperator, "in", None);
-    assert!(node.is_operator(&arena));
+    assert!(
+        node.token.token_type.is_always_operator()
+            || node.compute_is_multiplication_star(&arena)
+            || node.compute_is_bracket_operator(&arena)
+    );
 
     // An Operator token is always an operator
     let node2 = make_node(TokenType::Operator, "+", None);
-    assert!(node2.is_operator(&arena));
+    assert!(
+        node2.token.token_type.is_always_operator()
+            || node2.compute_is_multiplication_star(&arena)
+            || node2.compute_is_bracket_operator(&arena)
+    );
 
     // A Name is NOT an operator
     let node3 = make_node(TokenType::Name, "foo", None);
-    assert!(!node3.is_operator(&arena));
+    assert!(
+        !node3.token.token_type.is_always_operator()
+            && !node3.compute_is_multiplication_star(&arena)
+            && !node3.compute_is_bracket_operator(&arena)
+    );
 }
 
 #[test]

--- a/src/operator_precedence.rs
+++ b/src/operator_precedence.rs
@@ -57,7 +57,7 @@ impl OperatorPrecedence {
     }
 
     /// Determine precedence from a Node.
-    pub(crate) fn from_node(node: &Node, arena: &[Node]) -> Self {
+    pub(crate) fn from_node(node: &Node) -> Self {
         match node.token.token_type {
             TokenType::DoubleColon => Self::DoubleColon,
             TokenType::On => Self::On,
@@ -74,8 +74,8 @@ impl OperatorPrecedence {
             }
             TokenType::WordOperator => Self::from_word_operator(&node.value),
             TokenType::Operator => Self::from_symbol_operator(&node.value),
-            _ if node.is_bracket_operator(arena) => Self::SquareBrackets,
-            _ if node.is_multiplication_star(arena) => Self::Multiplication,
+            _ if node.is_bracket_operator => Self::SquareBrackets,
+            _ if node.is_multiplication_star => Self::Multiplication,
             _ => Self::Other,
         }
     }

--- a/src/operator_precedence_test.rs
+++ b/src/operator_precedence_test.rs
@@ -16,9 +16,9 @@ fn make_node(tt: TokenType, value: &str) -> Node {
 #[test]
 fn test_double_colon_precedence() {
     let node = make_node(TokenType::DoubleColon, "::");
-    let arena = vec![];
+
     assert_eq!(
-        OperatorPrecedence::from_node(&node, &arena),
+        OperatorPrecedence::from_node(&node),
         OperatorPrecedence::DoubleColon
     );
 }
@@ -28,18 +28,17 @@ fn test_boolean_operators() {
     let and_node = make_node(TokenType::BooleanOperator, "and");
     let or_node = make_node(TokenType::BooleanOperator, "or");
     let not_node = make_node(TokenType::BooleanOperator, "not");
-    let arena = vec![];
 
     assert_eq!(
-        OperatorPrecedence::from_node(&and_node, &arena),
+        OperatorPrecedence::from_node(&and_node),
         OperatorPrecedence::BoolAnd
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&or_node, &arena),
+        OperatorPrecedence::from_node(&or_node),
         OperatorPrecedence::BoolOr
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&not_node, &arena),
+        OperatorPrecedence::from_node(&not_node),
         OperatorPrecedence::BoolNot
     );
 }
@@ -49,18 +48,17 @@ fn test_word_operators() {
     let as_node = make_node(TokenType::WordOperator, "as");
     let in_node = make_node(TokenType::WordOperator, "in");
     let over_node = make_node(TokenType::WordOperator, "over");
-    let arena = vec![];
 
     assert_eq!(
-        OperatorPrecedence::from_node(&as_node, &arena),
+        OperatorPrecedence::from_node(&as_node),
         OperatorPrecedence::As
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&in_node, &arena),
+        OperatorPrecedence::from_node(&in_node),
         OperatorPrecedence::Membership
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&over_node, &arena),
+        OperatorPrecedence::from_node(&over_node),
         OperatorPrecedence::OtherTight
     );
 }
@@ -71,22 +69,21 @@ fn test_symbol_operators() {
     let mul = make_node(TokenType::Operator, "*");
     let eq = make_node(TokenType::Operator, "=");
     let exp = make_node(TokenType::Operator, "**");
-    let arena = vec![];
 
     assert_eq!(
-        OperatorPrecedence::from_node(&plus, &arena),
+        OperatorPrecedence::from_node(&plus),
         OperatorPrecedence::Addition
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&mul, &arena),
+        OperatorPrecedence::from_node(&mul),
         OperatorPrecedence::Multiplication
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&eq, &arena),
+        OperatorPrecedence::from_node(&eq),
         OperatorPrecedence::Comparators
     );
     assert_eq!(
-        OperatorPrecedence::from_node(&exp, &arena),
+        OperatorPrecedence::from_node(&exp),
         OperatorPrecedence::Exponent
     );
 }
@@ -105,47 +102,43 @@ fn test_tier_ordering() {
 fn test_between_and_precedence() {
     // "between" is a Membership-level operator
     let between_node = make_node(TokenType::WordOperator, "between");
-    let arena = vec![];
+
     assert_eq!(
-        OperatorPrecedence::from_node(&between_node, &arena),
+        OperatorPrecedence::from_node(&between_node),
         OperatorPrecedence::Membership
     );
 
     // "not between" also Membership
     let not_between = make_node(TokenType::WordOperator, "not between");
     assert_eq!(
-        OperatorPrecedence::from_node(&not_between, &arena),
+        OperatorPrecedence::from_node(&not_between),
         OperatorPrecedence::Membership
     );
 }
 
 #[test]
 fn test_presence_operators() {
-    let arena = vec![];
-
     let is_node = make_node(TokenType::WordOperator, "is");
     assert_eq!(
-        OperatorPrecedence::from_node(&is_node, &arena),
+        OperatorPrecedence::from_node(&is_node),
         OperatorPrecedence::Presence
     );
 
     let is_not_node = make_node(TokenType::WordOperator, "is not");
     assert_eq!(
-        OperatorPrecedence::from_node(&is_not_node, &arena),
+        OperatorPrecedence::from_node(&is_not_node),
         OperatorPrecedence::Presence
     );
 
     let exists_node = make_node(TokenType::WordOperator, "exists");
     assert_eq!(
-        OperatorPrecedence::from_node(&exists_node, &arena),
+        OperatorPrecedence::from_node(&exists_node),
         OperatorPrecedence::Presence
     );
 }
 
 #[test]
 fn test_membership_operators() {
-    let arena = vec![];
-
     for op in &[
         "in",
         "not in",
@@ -157,7 +150,7 @@ fn test_membership_operators() {
     ] {
         let node = make_node(TokenType::WordOperator, op);
         assert_eq!(
-            OperatorPrecedence::from_node(&node, &arena),
+            OperatorPrecedence::from_node(&node),
             OperatorPrecedence::Membership,
             "Expected Membership for '{}'",
             op
@@ -167,12 +160,10 @@ fn test_membership_operators() {
 
 #[test]
 fn test_pg_comparison_operators() {
-    let arena = vec![];
-
     for op in &["@>", "<@", "@@", "<->", "&&", "?|", "?&", "-|-"] {
         let node = make_node(TokenType::Operator, op);
         assert_eq!(
-            OperatorPrecedence::from_node(&node, &arena),
+            OperatorPrecedence::from_node(&node),
             OperatorPrecedence::Comparators,
             "Expected Comparators for '{}'",
             op
@@ -182,20 +173,18 @@ fn test_pg_comparison_operators() {
 
 #[test]
 fn test_on_precedence() {
-    let arena = vec![];
     let on_node = make_node(TokenType::On, "on");
     assert_eq!(
-        OperatorPrecedence::from_node(&on_node, &arena),
+        OperatorPrecedence::from_node(&on_node),
         OperatorPrecedence::On
     );
 }
 
 #[test]
 fn test_as_precedence() {
-    let arena = vec![];
     let as_node = make_node(TokenType::WordOperator, "as");
     assert_eq!(
-        OperatorPrecedence::from_node(&as_node, &arena),
+        OperatorPrecedence::from_node(&as_node),
         OperatorPrecedence::As
     );
 }

--- a/src/segment_test.rs
+++ b/src/segment_test.rs
@@ -4,14 +4,21 @@ use crate::token::{Token, TokenType};
 
 fn make_node(arena: &mut Vec<Node>, tt: TokenType, val: &str) -> usize {
     let idx = arena.len();
-    arena.push(Node::new(
+    let prev = if idx > 0 { Some(idx - 1) } else { None };
+    let mut node = Node::new(
         Token::new(tt, "", val, 0, val.len() as u32),
-        if idx > 0 { Some(idx - 1) } else { None },
+        prev,
         compact_str::CompactString::new(""),
         compact_str::CompactString::from(val),
         0,
         0,
-    ));
+    );
+    node.is_bracket_operator = node.compute_is_bracket_operator(arena);
+    node.is_multiplication_star = node.compute_is_multiplication_star(arena);
+    node.is_operator = node.token.token_type.is_always_operator()
+        || node.is_multiplication_star
+        || node.is_bracket_operator;
+    arena.push(node);
     idx
 }
 

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -93,7 +93,7 @@ impl LineSplitter {
         }
         // Split before operators — BUT NOT the AND after BETWEEN,
         // and NOT before cast (::) or colon (:) operators
-        if node.is_operator(arena) {
+        if node.is_operator {
             if node.is_the_and_after_between(arena) {
                 return false;
             }

--- a/src/splitter_test.rs
+++ b/src/splitter_test.rs
@@ -5,14 +5,20 @@ use crate::token::Token;
 fn make_node(arena: &mut Vec<Node>, tt: TokenType, val: &str, prefix: &str) -> NodeIndex {
     let idx = arena.len();
     let prev = if idx > 0 { Some(idx - 1) } else { None };
-    arena.push(Node::new(
+    let mut node = Node::new(
         Token::new(tt, "", val, 0, val.len() as u32),
         prev,
         CompactString::from(prefix),
         CompactString::from(val),
         0,
         0,
-    ));
+    );
+    node.is_bracket_operator = node.compute_is_bracket_operator(arena);
+    node.is_multiplication_star = node.compute_is_multiplication_star(arena);
+    node.is_operator = node.token.token_type.is_always_operator()
+        || node.is_multiplication_star
+        || node.is_bracket_operator;
+    arena.push(node);
     idx
 }
 
@@ -172,7 +178,7 @@ fn test_no_split_bracket_operator() {
     let _splitter = LineSplitter::new();
     // is_bracket_operator checks previous_sql_token - in our test the [
     // follows Name "arr", so it should be a bracket operator
-    assert!(arena[bracket].is_bracket_operator(&arena));
+    assert!(arena[bracket].compute_is_bracket_operator(&arena));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Cache `is_operator`, `is_bracket_operator`, and `is_multiplication_star` as bool fields on `Node`, computed once during `NodeManager::create_node()` instead of recomputing via backward arena walks (`get_previous_sql_token`) on every access during merging, splitting, and operator precedence classification
- Eliminate 3 redundant `is_multiline_jinja` node scans in `extract_components` by deferring validation to after the main node loop using the already-computed `line_has_multiline` flag
- Remove arena parameter from `OperatorPrecedence::from_node` since it no longer needs context lookups
- Bump version to 0.4.4

## Benchmark Results (all_fixtures_bench, top 10 by size)

| Fixture | Change |
|---|---|
| Fixture 4 | **-34%** |
| Fixture 3 | **-17%** |
| Fixture 5 | **-9%** |
| Fixtures 6-10 | **-6% to -7%** |
| Largest file (28KB) | within noise |

## CPU Profile Changes

- `Node::is_bracket_operator`: 9 → 0 samples (eliminated)
- `maybe_merge_lines`: 86 → 73 samples (-15%)

## Test plan

- [x] All 463 tests pass (264 unit + 62 CLI + 99 golden + 38 integration)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean (only pre-existing warnings)
- [x] Benchmarks verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)