### PR TITLE
Replace tokio with rayon for parallel file formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,12 +804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1149,13 +1143,13 @@ dependencies = [
  "phf",
  "predicates",
  "pretty_assertions",
+ "rayon",
  "serde",
  "similar",
  "smallvec",
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio",
  "toml",
 ]
 
@@ -1244,15 +1238,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 anyhow = "1"
-tokio = { version = "1", features = ["rt-multi-thread"] }
+rayon = "1.10"
 memmap2 = "0.9"
 indicatif = "0.17"
 similar = "2"

--- a/src/api.rs
+++ b/src/api.rs
@@ -66,10 +66,12 @@ pub fn format_string(source: &str, mode: &Mode) -> Result<String, SqlfmtError> {
 /// Run the formatter on a collection of files.
 ///
 /// Each file is an independent unit of work: read → format → write.
-/// Files are dispatched as concurrent tokio tasks, each using memory-mapped
-/// I/O for zero-copy reads and running CPU formatting on the blocking pool.
-/// This overlaps I/O and CPU work across files for maximum throughput.
+/// Files are processed in parallel using Rayon's thread pool, with
+/// memory-mapped I/O for zero-copy reads. Rayon's work-stealing scheduler
+/// efficiently distributes CPU-bound formatting across all threads.
 pub fn run(files: &[PathBuf], mode: &Mode) -> Report {
+    use rayon::prelude::*;
+
     let matching_paths = get_matching_paths(files, mode);
     let mut report = Report::new();
 
@@ -87,39 +89,16 @@ pub fn run(files: &[PathBuf], mode: &Mode) -> Report {
                 .unwrap_or(4)
         };
 
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .max_blocking_threads(concurrency)
-            .enable_all()
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrency)
             .build()
-            .expect("failed to build tokio runtime");
+            .expect("failed to build rayon thread pool");
 
-        let results = rt.block_on(async {
-            let mode = std::sync::Arc::new(mode.clone());
-            let mut handles = Vec::with_capacity(matching_paths.len());
-
-            for path in matching_paths {
-                let mode = mode.clone();
-                handles.push(tokio::spawn(async move {
-                    tokio::task::spawn_blocking(move || format_file(&path, &mode))
-                        .await
-                        .unwrap_or_else(|e| FileResult {
-                            path: PathBuf::new(),
-                            status: crate::report::FileStatus::Error,
-                            error: Some(format!("Task panicked: {}", e)),
-                        })
-                }));
-            }
-
-            let mut results = Vec::with_capacity(handles.len());
-            for handle in handles {
-                results.push(handle.await.unwrap_or_else(|e| FileResult {
-                    path: PathBuf::new(),
-                    status: crate::report::FileStatus::Error,
-                    error: Some(format!("Task panicked: {}", e)),
-                }));
-            }
-            results
+        let results: Vec<FileResult> = pool.install(|| {
+            matching_paths
+                .par_iter()
+                .map(|path| format_file(path, mode))
+                .collect()
         });
 
         for result in results {


### PR DESCRIPTION
## Summary
Replaced the tokio async runtime with rayon's thread pool for parallel file formatting. This simplifies the implementation by using a more appropriate tool for CPU-bound work while maintaining the same parallel processing capabilities.

## Key Changes
- Replaced tokio's multi-threaded async runtime with rayon's thread pool for file processing
- Simplified the concurrent file formatting logic from async/await with spawned blocking tasks to rayon's parallel iterator API
- Updated documentation to reflect the new parallelization strategy using rayon's work-stealing scheduler
- Removed tokio dependency and added rayon 1.10 dependency
- Bumped version from 0.4.5 to 0.4.6

## Implementation Details
- The new implementation uses `rayon::ThreadPoolBuilder` to create a thread pool sized to the system's concurrency level
- File processing now uses `par_iter()` with a simple `map()` operation, eliminating the complexity of managing async tasks and blocking thread spawning
- The thread pool is installed via `pool.install()` which ensures all parallel work uses the configured pool
- This approach is more idiomatic for CPU-bound work like SQL formatting, as rayon's work-stealing scheduler is optimized for such tasks

https://claude.ai/code/session_017YUK2fPTMYte3h4Kx4fsDn