### PR TITLE
Fix method chain formatting in Jinja templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/src/api.rs
+++ b/src/api.rs
@@ -549,6 +549,16 @@ fn normalize_jinja_structure(text: &str) -> String {
             }
             result.push(bytes[i] as char);
             i += 1;
+            // For method chains: strip spaces between ) and . (e.g. ") .get(" → ").get(")
+            if bytes[i - 1] == b')' {
+                let mut j = i;
+                while j < bytes.len() && bytes[j] == b' ' {
+                    j += 1;
+                }
+                if j < bytes.len() && bytes[j] == b'.' {
+                    i = j; // skip spaces before '.'
+                }
+            }
             continue;
         }
 

--- a/src/jinja_formatter.rs
+++ b/src/jinja_formatter.rs
@@ -788,9 +788,15 @@ impl JinjaFormatter {
         }
         result.push('\n');
         result.push_str(close_indent);
-        result.push_str(") ");
+        result.push(')');
         if !after_close.is_empty() {
+            // Don't add space before method chain continuation (e.g. ").get(...")
+            if !after_close.starts_with('.') {
+                result.push(' ');
+            }
             result.push_str(after_close);
+            result.push(' ');
+        } else {
             result.push(' ');
         }
         result.push_str(close_delim);

--- a/tests/data/unformatted/301_jinja_macro_method_chains.sql
+++ b/tests/data/unformatted/301_jinja_macro_method_chains.sql
@@ -1,0 +1,78 @@
+{% macro get_column_metadata(node_id, attr_key) %}
+	{% if execute %}
+		{% set results = [] %}
+		{% set cols = graph.nodes[node_id]['columns']  %}
+		{% if attr_key is not none %}
+			{% for col in cols if graph.nodes[node_id]['columns'][col]['meta'][attr_key] | length > 0 %}
+				{% set meta_dict = graph.nodes[node_id]['columns'][col]['meta'] %}
+				{% if attr_key in meta_dict %}
+					{% set attr_val = meta_dict[attr_key] %}
+					{% if "extra_inputs" in meta_dict %}
+						{% set extra = meta_dict['extra_inputs'] %}
+					{% else %}
+						{% set extra = [] %}
+					{% endif %}
+					{% set row = (col, attr_val, extra) %}
+					{% do results.append(row) %}
+				{% endif %}
+			{% endfor %}
+			{% for col in cols if graph.nodes[node_id]['columns'][col].get('config', {}).get('meta', {}).get(attr_key, '') | length > 0 %}
+				{% set meta_dict = graph.nodes[node_id]['columns'][col]['config']['meta'] %}
+				{% if attr_key in meta_dict %}
+					{% set attr_val = meta_dict[attr_key] %}
+					{% if "extra_inputs" in meta_dict %}
+						{% set extra = meta_dict['extra_inputs'] %}
+					{% else %}
+						{% set extra = [] %}
+					{% endif %}
+					{% set row = (col, attr_val, extra) %}
+					{% do results.append(row) %}
+				{% endif %}
+			{% endfor %}
+		{% else %}
+			{% do results.append(col|upper) %}
+		{% endif %}
+		{{ return(results) }}
+	{% endif %}
+{% endmacro %}
+
+)))))__SQLFMT_OUTPUT__(((((
+{% macro get_column_metadata(node_id, attr_key) %}
+    {% if execute %}
+        {% set results = [] %}
+        {% set cols = graph.nodes[node_id]["columns"] %}
+        {% if attr_key is not none %}
+            {% 
+                for col in cols if graph.nodes[node_id]["columns"][col]["meta"][attr_key] | length > 0
+            %}
+                {% set meta_dict = graph.nodes[node_id]["columns"][col]["meta"] %}
+                {% if attr_key in meta_dict %}
+                    {% set attr_val = meta_dict[attr_key] %}
+                    {% if "extra_inputs" in meta_dict %}
+                        {% set extra = meta_dict["extra_inputs"] %}
+                    {% else %} {% set extra = [] %}
+                    {% endif %}
+                    {% set row = (col, attr_val, extra) %}
+                    {% do results.append(row) %}
+                {% endif %}
+            {% endfor %}
+            {% for col in cols if graph.nodes[node_id]["columns"][col].get(
+                "config",
+                {}
+            ).get("meta", {}).get(attr_key, "") | length > 0 %}
+                {% set meta_dict = graph.nodes[node_id]["columns"][col]["config"]["meta"] %}
+                {% if attr_key in meta_dict %}
+                    {% set attr_val = meta_dict[attr_key] %}
+                    {% if "extra_inputs" in meta_dict %}
+                        {% set extra = meta_dict["extra_inputs"] %}
+                    {% else %} {% set extra = [] %}
+                    {% endif %}
+                    {% set row = (col, attr_val, extra) %}
+                    {% do results.append(row) %}
+                {% endif %}
+            {% endfor %}
+        {% else %} {% do results.append(col | upper) %}
+        {% endif %}
+        {{ return(results) }}
+    {% endif %}
+{% endmacro %}

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -121,6 +121,7 @@ golden_tests! {
     // Unformatted 300-series — Jinja formatting
     // =========================================================================
     golden_unformatted_300_jinjafmt => (default_mode, "tests/data/unformatted/300_jinjafmt.sql"),
+    golden_unformatted_301_jinja_macro_method_chains => (default_mode, "tests/data/unformatted/301_jinja_macro_method_chains.sql"),
 
     // =========================================================================
     // Unformatted 400-series — DDL/DML

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -472,3 +472,63 @@ fn test_fixture_for_update() {
     let second = format_string(&result, &default_mode()).unwrap();
     assert_eq!(result, second, "For update should be idempotent");
 }
+
+#[test]
+fn test_fixture_jinja_macro_with_method_chains() {
+    let source = r#"{% macro get_meta_objects(model_id, meta_key) %}
+	{% if execute %}
+              {% set meta_columns = [] %}
+	       {% set columns = graph.nodes[model_id]['columns']  %}
+              {% if meta_key is not none %}
+                     {% for column in columns if graph.nodes[model_id]['columns'][column]['meta'][meta_key] | length > 0 %}
+                            {% set meta_dict = graph.nodes[model_id]['columns'][column]['meta'] %}
+                            {% if meta_key in meta_dict %}
+                                   {% set policy_name = meta_dict[meta_key] %}
+                                   {% if "masking_policy_inputs" in meta_dict %}
+                                          {% set inputs = meta_dict['masking_policy_inputs'] %}
+                                   {% else %}
+                                          {% set inputs = [] %}
+                                   {% endif %}
+                                   {% set meta_tuple = (column, policy_name, inputs) %}
+                                   {% do meta_columns.append(meta_tuple) %}
+                            {% endif %}
+                     {% endfor %}
+                     {% for column in columns if graph.nodes[model_id]['columns'][column].get('config', {}).get('meta', {}).get(meta_key, '') | length > 0 %}
+                            {% set meta_dict = graph.nodes[model_id]['columns'][column]['config']['meta'] %}
+                            {% if meta_key in meta_dict %}
+                                   {% set policy_name = meta_dict[meta_key] %}
+                                   {% if "masking_policy_inputs" in meta_dict %}
+                                          {% set inputs = meta_dict['masking_policy_inputs'] %}
+                                   {% else %}
+                                          {% set inputs = [] %}
+                                   {% endif %}
+                                   {% set meta_tuple = (column, policy_name, inputs) %}
+                                   {% do meta_columns.append(meta_tuple) %}
+                            {% endif %}
+                     {% endfor %}
+              {% else %}
+                     {% do meta_columns.append(column|upper) %}
+              {% endif %}
+              {{ return(meta_columns) }}
+       {% endif %}
+{% endmacro %}
+"#;
+    let result = format_string(source, &default_mode()).unwrap();
+    assert!(
+        result.contains("{% macro"),
+        "Should contain macro: {}",
+        result
+    );
+    assert!(
+        result.contains("{% endmacro %}"),
+        "Should contain endmacro: {}",
+        result
+    );
+    assert!(
+        result.contains(".get("),
+        "Should preserve method chains: {}",
+        result
+    );
+    let second = format_string(&result, &default_mode()).unwrap();
+    assert_eq!(result, second, "Complex jinja macro should be idempotent");
+}


### PR DESCRIPTION
## Summary
This PR fixes the formatting of method chains in Jinja templates by removing unnecessary spaces between closing parentheses and dots (e.g., `) .get(` → ").get(`).

## Key Changes
- **src/jinja_formatter.rs**: Modified the closing parenthesis handling to not automatically add a space when the following content starts with a dot (method chain continuation)
- **src/api.rs**: Added logic to `normalize_jinja_structure()` to strip spaces between `)` and `.` in method chains, ensuring consistent normalization
- **tests/integration_test.rs**: Added comprehensive test case `test_fixture_jinja_macro_with_method_chains()` that validates:
  - Complex Jinja macros with nested conditionals and loops are preserved
  - Method chains like `.get('config', {}).get('meta', {})` are properly formatted
  - Formatting is idempotent (formatting twice produces the same result)

## Implementation Details
The fix addresses method chain formatting at two levels:
1. During normalization: spaces between `)` and `.` are removed to create a canonical form
2. During formatting: the formatter detects when `after_close` content starts with `.` and skips adding a space before it

This ensures that complex Jinja templates with method chains on dictionary/object access are formatted consistently and idempotently.

https://claude.ai/code/session_01JBHCH6YL9a1p3exeG9JGMW