### PR TITLE
Preserve space before parenthesis for Jinja block keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/src/jinja_formatter.rs
+++ b/src/jinja_formatter.rs
@@ -475,7 +475,12 @@ impl JinjaFormatter {
                 if trimmed_len > 0 {
                     let last_byte = result.as_bytes()[trimmed_len - 1];
                     if last_byte.is_ascii_alphanumeric() || last_byte == b'_' || last_byte == b'.' {
-                        result.truncate(trimmed_len);
+                        // Don't strip space before ( if the preceding word is a
+                        // Jinja block keyword (if, for, etc.) — removing it would
+                        // cause the lexer to misidentify the token type.
+                        if !is_jinja_keyword_before_paren(&result[..trimmed_len]) {
+                            result.truncate(trimmed_len);
+                        }
                     }
                 }
                 result.push('(');
@@ -1087,6 +1092,35 @@ fn split_by_tilde(s: &str) -> Vec<&str> {
         }
     }
     parts
+}
+
+/// Check if the word immediately before position `end` in `s` is a Jinja block
+/// keyword that must keep a space before `(` to avoid being misidentified by the
+/// lexer. For example, `if (x)` must not become `if(x)`.
+fn is_jinja_keyword_before_paren(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    // Walk backwards to find the start of the word
+    let mut end = bytes.len();
+    while end > 0 && (bytes[end - 1].is_ascii_alphanumeric() || bytes[end - 1] == b'_') {
+        end -= 1;
+    }
+    let word = &s[end..];
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "if" | "elif"
+            | "for"
+            | "macro"
+            | "call"
+            | "set"
+            | "test"
+            | "snapshot"
+            | "materialization"
+            | "not"
+            | "and"
+            | "or"
+            | "in"
+            | "is"
+    )
 }
 
 #[cfg(test)]

--- a/tests/data/unformatted/225_dbt_snowflake_incremental_macro.sql
+++ b/tests/data/unformatted/225_dbt_snowflake_incremental_macro.sql
@@ -1,0 +1,331 @@
+{% macro dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(config) %}
+  {#-- Find and validate the incremental strategy #}
+  {%- set strategy = config.get("incremental_strategy", default="merge") -%}
+
+  {% set invalid_strategy_msg -%}
+    Invalid incremental strategy provided: {{ strategy }}
+    Expected one of: 'merge', 'delete+insert', 'merge+check'
+  {%- endset %}
+  {% if strategy not in ['merge', 'delete+insert', 'merge+check'] %}
+    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+  {% endif %}
+
+  {% do return(strategy) %}
+{% endmacro %}
+
+{% macro dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols) %}
+  {% if strategy == 'merge' %}
+    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+  {% elif strategy == 'merge+check' %}
+    {% do return(get_merge_check_sql(target_relation, tmp_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols)) %}
+  {% elif strategy == 'delete+insert' %}
+    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+  {% else %}
+    {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
+  {% endif %}
+{% endmacro %}
+
+{% macro get_merge_check_sql(target, source, unique_key, dest_columns, check_cols_config, exclude_from_check_cols) -%}
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+    {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute="quoted") | list) -%}
+    {%- set sql_header = config.get('sql_header', none) -%}
+
+    {{ sql_header if sql_header is not none }}
+
+    merge into {{ target }} as DBT_INTERNAL_DEST
+        using {{ source }} as DBT_INTERNAL_SOURCE
+        on DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+
+    {% if check_cols_config == 'all' %}
+      {% set column_added, unfiltered_check_cols = snapshot_check_all_get_existing_columns(model, True) %}
+    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
+      {% set unfiltered_check_cols = check_cols_config %}
+    {% else %}
+      {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
+    {% endif %}
+
+    {% if (exclude_from_check_cols | length) > 0 %}
+        {% do exclude_from_check_cols.append(unique_key) %}
+    {% else %}
+      {% set exclude_from_check_cols = [unique_key] %}
+    {% endif %}
+    {% set check_cols = compare_lists(uppercase_list(unfiltered_check_cols), uppercase_list(exclude_from_check_cols)) %}
+
+    when matched and
+      {% for col in check_cols -%}
+          DBT_INTERNAL_DEST.{{ col }} != DBT_INTERNAL_SOURCE.{{ col }}
+          or
+          (
+              ((DBT_INTERNAL_DEST.{{ col }} is null) and not (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              or
+              ((not DBT_INTERNAL_DEST.{{ col }} is null) and (DBT_INTERNAL_SOURCE.{{ col }} is null))
+          )
+          {%- if not loop.last %} or {% endif -%}
+      {%- endfor %} then update set
+      {% for column_name in update_columns -%}
+          {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}
+          {%- if not loop.last %}, {%- endif %}
+      {%- endfor %}
+
+    when not matched then insert
+        ({{ dest_cols_csv }})
+    values
+        ({{ dest_cols_csv }})
+
+{% endmacro %}
+
+
+
+-- based on incremental materialzation
+-- adds changed_cols option that automatically triggers full refresh if columns are changed
+{% materialization incremental_full_refresh_on_schema_change, adapter='snowflake' -%}
+
+  {% set original_query_tag = set_query_tag() %}
+
+  {%- set unique_key = config.get('unique_key') -%}
+  {%- set check_cols = config.get('check_cols') -%}
+  {%- set exclude_from_check_cols = config.get('exclude_from_check_cols') -%}
+
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
+
+  {% set target_relation = this %}
+  {% set existing_relation = load_relation(this) %}
+  {% set tmp_relation = make_temp_relation(this) %}
+
+  {#-- Validate early so we don't run SQL if the strategy is invalid --#}
+  {% set strategy = dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(config) -%}
+
+  -- setup
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if existing_relation is none %}
+    {% set build_sql = create_table_as(False, target_relation, sql) %}
+  {% elif existing_relation.is_view %}
+    {#-- Can't overwrite a view with a table - we must drop --#}
+    {{ log("Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.", info=true) }}
+    {% do adapter.drop_relation(existing_relation) %}
+    {% set build_sql = create_table_as(False, target_relation, sql) %}
+  {% elif full_refresh_mode %}
+    {% set build_sql = create_table_as(False, target_relation, sql) %}
+  {% else %}
+    {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+    {% do adapter.expand_target_column_types(
+           from_relation=tmp_relation,
+           to_relation=target_relation) %}
+    {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
+    {% set build_sql = dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols) %}
+  {% endif %}
+
+  {%- call statement('main') -%}
+    {{ build_sql }}
+  {%- endcall -%}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {% set target_relation = target_relation.incorporate(type='table') %}
+  {% do persist_docs(target_relation, model) %}
+
+  {% do unset_query_tag(original_query_tag) %}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}
+)))))__SQLFMT_OUTPUT__(((((
+{% macro dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(
+    config
+) %}
+    {#-- Find and validate the incremental strategy #}
+    {%- set strategy = config.get("incremental_strategy", default="merge") -%}
+
+    {% set invalid_strategy_msg -%}
+    Invalid incremental strategy provided: {{ strategy }}
+    Expected one of: 'merge', 'delete+insert', 'merge+check'
+    {%- endset %}
+    {% if strategy not in ["merge", "delete+insert", "merge+check"] %}
+        {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% endif %}
+
+    {% do return(strategy) %}
+{% endmacro %}
+
+{% macro dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(
+    strategy,
+    tmp_relation,
+    target_relation,
+    unique_key,
+    dest_columns,
+    check_cols,
+    exclude_from_check_cols
+) %}
+    {% if strategy == "merge" %}
+        {% do return(
+            get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)
+        ) %}
+    {% elif strategy == "merge+check" %}
+        {% do return(
+            get_merge_check_sql(target_relation, tmp_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols)
+        ) %}
+    {% elif strategy == "delete+insert" %}
+        {% do return(
+            get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)
+        ) %}
+    {% else %} {% do exceptions.raise_compiler_error("invalid strategy: " ~ strategy) %}
+    {% endif %}
+{% endmacro %}
+
+{% macro get_merge_check_sql(
+    target,
+    source,
+    unique_key,
+    dest_columns,
+    check_cols_config,
+    exclude_from_check_cols
+) -%}
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+    {%- set update_columns = config.get(
+        "merge_update_columns",
+        default = dest_columns | map(attribute="quoted") | list
+    ) -%}
+    {%- set sql_header = config.get("sql_header", none) -%}
+
+    {{ sql_header if sql_header is not none }}
+
+    merge into {{ target }} as DBT_INTERNAL_DEST
+        using {{ source }} as DBT_INTERNAL_SOURCE
+        on DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+
+    {% if check_cols_config == "all" %}
+        {% set column_added, unfiltered_check_cols = snapshot_check_all_get_existing_columns(
+            model,
+            True
+        ) %}
+    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
+        {% set unfiltered_check_cols = check_cols_config %}
+    {% else %}
+        {% do exceptions.raise_compiler_error(
+            "Invalid value for 'check_cols': " ~ check_cols_config
+        ) %}
+    {% endif %}
+
+    {% if (exclude_from_check_cols | length) > 0 %}
+        {% do exclude_from_check_cols.append(unique_key) %}
+    {% else %} {% set exclude_from_check_cols = [unique_key] %}
+    {% endif %}
+    {% set check_cols = compare_lists(
+        uppercase_list(unfiltered_check_cols),
+        uppercase_list(exclude_from_check_cols)
+    ) %}
+
+    when matched and
+    {% for col in check_cols -%}
+          DBT_INTERNAL_DEST.{{ col }} != DBT_INTERNAL_SOURCE.{{ col }}
+          or
+          (
+              ((DBT_INTERNAL_DEST.{{ col }} is null) and not (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              or
+              ((not DBT_INTERNAL_DEST.{{ col }} is null) and (DBT_INTERNAL_SOURCE.{{ col }} is null))
+          )
+          {%- if not loop.last %} or {% endif -%}
+      {%- endfor %} then update set
+        {% for column_name in update_columns -%}
+          {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}
+          {%- if not loop.last %}, {%- endif %}
+            {%- endfor %}
+
+    when not matched then insert
+        ({{ dest_cols_csv }})
+    values
+        ({{ dest_cols_csv }})
+
+        {% endmacro %}
+
+        -- based on incremental materialzation
+        -- adds changed_cols option that automatically triggers full refresh if columns
+        -- are changed
+        {% 
+            materialization incremental_full_refresh_on_schema_change, adapter = "snowflake"
+        -%}
+
+            {% set original_query_tag = set_query_tag() %}
+
+            {%- set unique_key = config.get("unique_key") -%}
+            {%- set check_cols = config.get("check_cols") -%}
+            {%- set exclude_from_check_cols = config.get("exclude_from_check_cols") -%}
+
+            {%- set full_refresh_mode = (should_full_refresh()) -%}
+
+            {% set target_relation = this %}
+            {% set existing_relation = load_relation(this) %}
+            {% set tmp_relation = make_temp_relation(this) %}
+
+            {#-- Validate early so we don't run SQL if the strategy is invalid --#}
+            {% set strategy = dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(
+                config
+            ) -%}
+
+            -- setup
+            {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+            -- `BEGIN` happens here:
+            {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+            {% if existing_relation is none %}
+                {% set build_sql = create_table_as(False, target_relation, sql) %}
+            {% elif existing_relation.is_view %}
+                {#-- Can't overwrite a view with a table - we must drop --#}
+                {{
+                    log(
+                        "Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.",
+                        info=true,
+                    )
+                }}
+                {% do adapter.drop_relation(existing_relation) %}
+                {% set build_sql = create_table_as(False, target_relation, sql) %}
+            {% elif full_refresh_mode %}
+                {% set build_sql = create_table_as(False, target_relation, sql) %}
+            {% else %} {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+                {% do adapter.expand_target_column_types(
+                    from_relation=tmp_relation,
+                    to_relation=target_relation
+                ) %}
+                {% set dest_columns = adapter.get_columns_in_relation(
+                    target_relation
+                ) %}
+                {% set build_sql = dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(
+                    strategy,
+                    tmp_relation,
+                    target_relation,
+                    unique_key,
+                    dest_columns,
+                    check_cols,
+                    exclude_from_check_cols
+                ) %}
+            {% endif %}
+
+            {%- call statement("main") -%}
+            {{ build_sql }}
+        {%- endcall -%}
+
+        {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+        -- `COMMIT` happens here
+        {{ adapter.commit() }}
+
+        {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+        {% set target_relation = target_relation.incorporate(type="table") %}
+        {% do persist_docs(target_relation, model) %}
+
+        {% do unset_query_tag(original_query_tag) %}
+
+        {{ return({"relations": [target_relation]}) }}
+
+    {%- endmaterialization %}

--- a/tests/data/unformatted/225_dbt_snowflake_incremental_macro.sql
+++ b/tests/data/unformatted/225_dbt_snowflake_incremental_macro.sql
@@ -1,122 +1,122 @@
-{% macro dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(config) %}
-  {#-- Find and validate the incremental strategy #}
-  {%- set strategy = config.get("incremental_strategy", default="merge") -%}
+-- Regression test: {% if (var | filter) > 0 %} must preserve space between
+-- keyword and paren so the lexer identifies it as JinjaBlockStart, not
+-- JinjaStatement.
+{% macro validate_strategy(config) %}
+  {#-- Validate the strategy #}
+  {%- set strategy = config.get("strategy", default="merge") -%}
 
-  {% set invalid_strategy_msg -%}
-    Invalid incremental strategy provided: {{ strategy }}
-    Expected one of: 'merge', 'delete+insert', 'merge+check'
+  {% set error_msg -%}
+    Invalid strategy: {{ strategy }}
+    Expected one of: 'merge', 'append', 'upsert'
   {%- endset %}
-  {% if strategy not in ['merge', 'delete+insert', 'merge+check'] %}
-    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+  {% if strategy not in ['merge', 'append', 'upsert'] %}
+    {% do exceptions.raise_compiler_error(error_msg) %}
   {% endif %}
 
   {% do return(strategy) %}
 {% endmacro %}
 
-{% macro dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols) %}
+{% macro get_incremental_sql(strategy, source_rel, target_rel, pk, columns, check_list, exclude_list) %}
   {% if strategy == 'merge' %}
-    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
-  {% elif strategy == 'merge+check' %}
-    {% do return(get_merge_check_sql(target_relation, tmp_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols)) %}
-  {% elif strategy == 'delete+insert' %}
-    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+    {% do return(build_merge_sql(target_rel, source_rel, pk, columns)) %}
+  {% elif strategy == 'upsert' %}
+    {% do return(build_upsert_sql(target_rel, source_rel, pk, columns, check_list, exclude_list)) %}
+  {% elif strategy == 'append' %}
+    {% do return(build_append_sql(target_rel, source_rel, pk, columns)) %}
   {% else %}
-    {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
+    {% do exceptions.raise_compiler_error('unknown strategy: ' ~ strategy) %}
   {% endif %}
 {% endmacro %}
 
-{% macro get_merge_check_sql(target, source, unique_key, dest_columns, check_cols_config, exclude_from_check_cols) -%}
-    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
-    {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute="quoted") | list) -%}
-    {%- set sql_header = config.get('sql_header', none) -%}
+{% macro build_upsert_sql(tgt, src, pk, columns, check_cfg, exclude_cfg) -%}
+    {%- set cols_csv = get_quoted_csv(columns | map(attribute="name")) -%}
+    {%- set upd_columns = config.get('update_columns', default = columns | map(attribute="quoted") | list) -%}
+    {%- set header = config.get('sql_header', none) -%}
 
-    {{ sql_header if sql_header is not none }}
+    {{ header if header is not none }}
 
-    merge into {{ target }} as DBT_INTERNAL_DEST
-        using {{ source }} as DBT_INTERNAL_SOURCE
-        on DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+    merge into {{ tgt }} as TGT
+        using {{ src }} as SRC
+        on SRC.{{ pk }} = TGT.{{ pk }}
 
-    {% if check_cols_config == 'all' %}
-      {% set column_added, unfiltered_check_cols = snapshot_check_all_get_existing_columns(model, True) %}
-    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
-      {% set unfiltered_check_cols = check_cols_config %}
+    {% if check_cfg == 'all' %}
+      {% set found, raw_check_cols = get_all_existing_columns(model, True) %}
+    {% elif check_cfg is iterable and (check_cfg | length) > 0 %}
+      {% set raw_check_cols = check_cfg %}
     {% else %}
-      {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
+      {% do exceptions.raise_compiler_error("Bad value for 'check_cfg': " ~ check_cfg) %}
     {% endif %}
 
-    {% if (exclude_from_check_cols | length) > 0 %}
-        {% do exclude_from_check_cols.append(unique_key) %}
+    {% if (exclude_cfg | length) > 0 %}
+        {% do exclude_cfg.append(pk) %}
     {% else %}
-      {% set exclude_from_check_cols = [unique_key] %}
+      {% set exclude_cfg = [pk] %}
     {% endif %}
-    {% set check_cols = compare_lists(uppercase_list(unfiltered_check_cols), uppercase_list(exclude_from_check_cols)) %}
+    {% set check_cols = diff_lists(upper_list(raw_check_cols), upper_list(exclude_cfg)) %}
 
     when matched and
       {% for col in check_cols -%}
-          DBT_INTERNAL_DEST.{{ col }} != DBT_INTERNAL_SOURCE.{{ col }}
+          TGT.{{ col }} != SRC.{{ col }}
           or
           (
-              ((DBT_INTERNAL_DEST.{{ col }} is null) and not (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              ((TGT.{{ col }} is null) and not (SRC.{{ col }} is null))
               or
-              ((not DBT_INTERNAL_DEST.{{ col }} is null) and (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              ((not TGT.{{ col }} is null) and (SRC.{{ col }} is null))
           )
           {%- if not loop.last %} or {% endif -%}
       {%- endfor %} then update set
-      {% for column_name in update_columns -%}
-          {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}
+      {% for c in upd_columns -%}
+          {{ c }} = SRC.{{ c }}
           {%- if not loop.last %}, {%- endif %}
       {%- endfor %}
 
     when not matched then insert
-        ({{ dest_cols_csv }})
+        ({{ cols_csv }})
     values
-        ({{ dest_cols_csv }})
+        ({{ cols_csv }})
 
 {% endmacro %}
 
 
+{% materialization my_incremental, adapter='snowflake' -%}
 
--- based on incremental materialzation
--- adds changed_cols option that automatically triggers full refresh if columns are changed
-{% materialization incremental_full_refresh_on_schema_change, adapter='snowflake' -%}
+  {% set qtag = set_query_tag() %}
 
-  {% set original_query_tag = set_query_tag() %}
+  {%- set pk = config.get('unique_key') -%}
+  {%- set check_list = config.get('check_cols') -%}
+  {%- set exclude_list = config.get('exclude_cols') -%}
 
-  {%- set unique_key = config.get('unique_key') -%}
-  {%- set check_cols = config.get('check_cols') -%}
-  {%- set exclude_from_check_cols = config.get('exclude_from_check_cols') -%}
+  {%- set do_full_refresh = (should_full_refresh()) -%}
 
-  {%- set full_refresh_mode = (should_full_refresh()) -%}
-
-  {% set target_relation = this %}
-  {% set existing_relation = load_relation(this) %}
-  {% set tmp_relation = make_temp_relation(this) %}
+  {% set target_rel = this %}
+  {% set existing_rel = load_relation(this) %}
+  {% set tmp_rel = make_temp_relation(this) %}
 
   {#-- Validate early so we don't run SQL if the strategy is invalid --#}
-  {% set strategy = dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(config) -%}
+  {% set strategy = validate_strategy(config) -%}
 
   -- setup
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- `BEGIN` happens here:
+  -- begin
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if existing_relation is none %}
-    {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% elif existing_relation.is_view %}
+  {% if existing_rel is none %}
+    {% set build_sql = create_table_as(False, target_rel, sql) %}
+  {% elif existing_rel.is_view %}
     {#-- Can't overwrite a view with a table - we must drop --#}
-    {{ log("Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.", info=true) }}
-    {% do adapter.drop_relation(existing_relation) %}
-    {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% elif full_refresh_mode %}
-    {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {{ log("Dropping " ~ target_rel ~ " because it is a view and this model is a table.", info=true) }}
+    {% do adapter.drop_relation(existing_rel) %}
+    {% set build_sql = create_table_as(False, target_rel, sql) %}
+  {% elif do_full_refresh %}
+    {% set build_sql = create_table_as(False, target_rel, sql) %}
   {% else %}
-    {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+    {% do run_query(create_table_as(True, tmp_rel, sql)) %}
     {% do adapter.expand_target_column_types(
-           from_relation=tmp_relation,
-           to_relation=target_relation) %}
-    {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
-    {% set build_sql = dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols) %}
+           from_relation=tmp_rel,
+           to_relation=target_rel) %}
+    {% set columns = adapter.get_columns_in_relation(target_rel) %}
+    {% set build_sql = get_incremental_sql(strategy, tmp_rel, target_rel, pk, columns, check_list, exclude_list) %}
   {% endif %}
 
   {%- call statement('main') -%}
@@ -125,188 +125,163 @@
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  -- `COMMIT` happens here
+  -- commit
   {{ adapter.commit() }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-  {% set target_relation = target_relation.incorporate(type='table') %}
-  {% do persist_docs(target_relation, model) %}
+  {% set target_rel = target_rel.incorporate(type='table') %}
+  {% do persist_docs(target_rel, model) %}
 
-  {% do unset_query_tag(original_query_tag) %}
+  {% do unset_query_tag(qtag) %}
 
-  {{ return({'relations': [target_relation]}) }}
+  {{ return({'relations': [target_rel]}) }}
 
 {%- endmaterialization %}
 )))))__SQLFMT_OUTPUT__(((((
-{% macro dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(
-    config
-) %}
-    {#-- Find and validate the incremental strategy #}
-    {%- set strategy = config.get("incremental_strategy", default="merge") -%}
-
-    {% set invalid_strategy_msg -%}
-    Invalid incremental strategy provided: {{ strategy }}
-    Expected one of: 'merge', 'delete+insert', 'merge+check'
+-- Regression test: {% if (var | filter) > 0 %} must preserve space between
+-- keyword and paren so the lexer identifies it as JinjaBlockStart, not
+-- JinjaStatement.
+{% macro validate_strategy(config) %}
+    {#-- Validate the strategy #}
+    {%- set strategy = config.get("strategy", default="merge") -%} {% set error_msg -%}
+    Invalid strategy: {{ strategy }}
+    Expected one of: 'merge', 'append', 'upsert'
     {%- endset %}
-    {% if strategy not in ["merge", "delete+insert", "merge+check"] %}
-        {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% if strategy not in ["merge", "append", "upsert"] %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
     {% endif %}
 
     {% do return(strategy) %}
 {% endmacro %}
 
-{% macro dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(
+{% macro get_incremental_sql(
     strategy,
-    tmp_relation,
-    target_relation,
-    unique_key,
-    dest_columns,
-    check_cols,
-    exclude_from_check_cols
+    source_rel,
+    target_rel,
+    pk,
+    columns,
+    check_list,
+    exclude_list
 ) %}
     {% if strategy == "merge" %}
+        {% do return(build_merge_sql(target_rel, source_rel, pk, columns)) %}
+    {% elif strategy == "upsert" %}
         {% do return(
-            get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)
+            build_upsert_sql(target_rel, source_rel, pk, columns, check_list, exclude_list)
         ) %}
-    {% elif strategy == "merge+check" %}
-        {% do return(
-            get_merge_check_sql(target_relation, tmp_relation, unique_key, dest_columns, check_cols, exclude_from_check_cols)
-        ) %}
-    {% elif strategy == "delete+insert" %}
-        {% do return(
-            get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)
-        ) %}
-    {% else %} {% do exceptions.raise_compiler_error("invalid strategy: " ~ strategy) %}
+    {% elif strategy == "append" %}
+        {% do return(build_append_sql(target_rel, source_rel, pk, columns)) %}
+    {% else %} {% do exceptions.raise_compiler_error("unknown strategy: " ~ strategy) %}
     {% endif %}
 {% endmacro %}
 
-{% macro get_merge_check_sql(
-    target,
-    source,
-    unique_key,
-    dest_columns,
-    check_cols_config,
-    exclude_from_check_cols
-) -%}
-    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
-    {%- set update_columns = config.get(
-        "merge_update_columns",
-        default = dest_columns | map(attribute="quoted") | list
+{% macro build_upsert_sql(tgt, src, pk, columns, check_cfg, exclude_cfg) -%}
+    {%- set cols_csv = get_quoted_csv(columns | map(attribute="name")) -%}
+    {%- set upd_columns = config.get(
+        "update_columns",
+        default = columns | map(attribute="quoted") | list
     ) -%}
-    {%- set sql_header = config.get("sql_header", none) -%}
+    {%- set header = config.get("sql_header", none) -%}
 
-    {{ sql_header if sql_header is not none }}
+    {{ header if header is not none }}
 
-    merge into {{ target }} as DBT_INTERNAL_DEST
-        using {{ source }} as DBT_INTERNAL_SOURCE
-        on DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+    merge into {{ tgt }} as TGT
+        using {{ src }} as SRC
+        on SRC.{{ pk }} = TGT.{{ pk }}
 
-    {% if check_cols_config == "all" %}
-        {% set column_added, unfiltered_check_cols = snapshot_check_all_get_existing_columns(
-            model,
-            True
-        ) %}
-    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
-        {% set unfiltered_check_cols = check_cols_config %}
+    {% if check_cfg == "all" %}
+        {% set found, raw_check_cols = get_all_existing_columns(model, True) %}
+    {% elif check_cfg is iterable and (check_cfg | length) > 0 %}
+        {% set raw_check_cols = check_cfg %}
     {% else %}
         {% do exceptions.raise_compiler_error(
-            "Invalid value for 'check_cols': " ~ check_cols_config
+            "Bad value for 'check_cfg': " ~ check_cfg
         ) %}
     {% endif %}
 
-    {% if (exclude_from_check_cols | length) > 0 %}
-        {% do exclude_from_check_cols.append(unique_key) %}
-    {% else %} {% set exclude_from_check_cols = [unique_key] %}
+    {% if (exclude_cfg | length) > 0 %} {% do exclude_cfg.append(pk) %}
+    {% else %} {% set exclude_cfg = [pk] %}
     {% endif %}
-    {% set check_cols = compare_lists(
-        uppercase_list(unfiltered_check_cols),
-        uppercase_list(exclude_from_check_cols)
+    {% set check_cols = diff_lists(
+        upper_list(raw_check_cols),
+        upper_list(exclude_cfg)
     ) %}
 
     when matched and
     {% for col in check_cols -%}
-          DBT_INTERNAL_DEST.{{ col }} != DBT_INTERNAL_SOURCE.{{ col }}
+          TGT.{{ col }} != SRC.{{ col }}
           or
           (
-              ((DBT_INTERNAL_DEST.{{ col }} is null) and not (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              ((TGT.{{ col }} is null) and not (SRC.{{ col }} is null))
               or
-              ((not DBT_INTERNAL_DEST.{{ col }} is null) and (DBT_INTERNAL_SOURCE.{{ col }} is null))
+              ((not TGT.{{ col }} is null) and (SRC.{{ col }} is null))
           )
           {%- if not loop.last %} or {% endif -%}
       {%- endfor %} then update set
-        {% for column_name in update_columns -%}
-          {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}
+        {% for c in upd_columns -%}
+          {{ c }} = SRC.{{ c }}
           {%- if not loop.last %}, {%- endif %}
             {%- endfor %}
 
     when not matched then insert
-        ({{ dest_cols_csv }})
+        ({{ cols_csv }})
     values
-        ({{ dest_cols_csv }})
+        ({{ cols_csv }})
 
         {% endmacro %}
 
-        -- based on incremental materialzation
-        -- adds changed_cols option that automatically triggers full refresh if columns
-        -- are changed
-        {% 
-            materialization incremental_full_refresh_on_schema_change, adapter = "snowflake"
-        -%}
+        {% materialization my_incremental, adapter = "snowflake" -%}
 
-            {% set original_query_tag = set_query_tag() %}
+            {% set qtag = set_query_tag() %}
 
-            {%- set unique_key = config.get("unique_key") -%}
-            {%- set check_cols = config.get("check_cols") -%}
-            {%- set exclude_from_check_cols = config.get("exclude_from_check_cols") -%}
+            {%- set pk = config.get("unique_key") -%}
+            {%- set check_list = config.get("check_cols") -%}
+            {%- set exclude_list = config.get("exclude_cols") -%}
 
-            {%- set full_refresh_mode = (should_full_refresh()) -%}
+            {%- set do_full_refresh = (should_full_refresh()) -%}
 
-            {% set target_relation = this %}
-            {% set existing_relation = load_relation(this) %}
-            {% set tmp_relation = make_temp_relation(this) %}
+            {% set target_rel = this %}
+            {% set existing_rel = load_relation(this) %}
+            {% set tmp_rel = make_temp_relation(this) %}
 
             {#-- Validate early so we don't run SQL if the strategy is invalid --#}
-            {% set strategy = dbt_snowflake_validate_get_incremental_full_refresh_on_schema_change_strategy(
-                config
-            ) -%}
+            {% set strategy = validate_strategy(config) -%}
 
             -- setup
             {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-            -- `BEGIN` happens here:
+            -- begin
             {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-            {% if existing_relation is none %}
-                {% set build_sql = create_table_as(False, target_relation, sql) %}
-            {% elif existing_relation.is_view %}
+            {% if existing_rel is none %}
+                {% set build_sql = create_table_as(False, target_rel, sql) %}
+            {% elif existing_rel.is_view %}
                 {#-- Can't overwrite a view with a table - we must drop --#}
                 {{
                     log(
-                        "Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.",
+                        "Dropping " ~ target_rel ~ " because it is a view and this model is a table.",
                         info=true,
                     )
                 }}
-                {% do adapter.drop_relation(existing_relation) %}
-                {% set build_sql = create_table_as(False, target_relation, sql) %}
-            {% elif full_refresh_mode %}
-                {% set build_sql = create_table_as(False, target_relation, sql) %}
-            {% else %} {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+                {% do adapter.drop_relation(existing_rel) %}
+                {% set build_sql = create_table_as(False, target_rel, sql) %}
+            {% elif do_full_refresh %}
+                {% set build_sql = create_table_as(False, target_rel, sql) %}
+            {% else %} {% do run_query(create_table_as(True, tmp_rel, sql)) %}
                 {% do adapter.expand_target_column_types(
-                    from_relation=tmp_relation,
-                    to_relation=target_relation
+                    from_relation=tmp_rel,
+                    to_relation=target_rel
                 ) %}
-                {% set dest_columns = adapter.get_columns_in_relation(
-                    target_relation
-                ) %}
-                {% set build_sql = dbt_snowflake_get_incremental_full_refresh_on_schema_change_sql(
+                {% set columns = adapter.get_columns_in_relation(target_rel) %}
+                {% set build_sql = get_incremental_sql(
                     strategy,
-                    tmp_relation,
-                    target_relation,
-                    unique_key,
-                    dest_columns,
-                    check_cols,
-                    exclude_from_check_cols
+                    tmp_rel,
+                    target_rel,
+                    pk,
+                    columns,
+                    check_list,
+                    exclude_list
                 ) %}
             {% endif %}
 
@@ -316,16 +291,16 @@
 
         {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-        -- `COMMIT` happens here
+        -- commit
         {{ adapter.commit() }}
 
         {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-        {% set target_relation = target_relation.incorporate(type="table") %}
-        {% do persist_docs(target_relation, model) %}
+        {% set target_rel = target_rel.incorporate(type="table") %}
+        {% do persist_docs(target_rel, model) %}
 
-        {% do unset_query_tag(original_query_tag) %}
+        {% do unset_query_tag(qtag) %}
 
-        {{ return({"relations": [target_relation]}) }}
+        {{ return({"relations": [target_rel]}) }}
 
     {%- endmaterialization %}

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -116,6 +116,7 @@ golden_tests! {
     golden_unformatted_222_jinja_unbalanced_brackets => (default_mode, "tests/data/unformatted/222_jinja_unbalanced_brackets.sql"),
     golden_unformatted_223_dbt_config_nested_quotes => (default_mode, "tests/data/unformatted/223_dbt_config_nested_quotes.sql"),
     golden_unformatted_224_dbt_config_unique_key_nested_quotes => (default_mode, "tests/data/unformatted/224_dbt_config_unique_key_nested_quotes.sql"),
+    golden_unformatted_225_dbt_snowflake_incremental_macro => (default_mode, "tests/data/unformatted/225_dbt_snowflake_incremental_macro.sql"),
 
     // =========================================================================
     // Unformatted 300-series — Jinja formatting


### PR DESCRIPTION
## Summary
Fix a lexer issue where spaces before parentheses following Jinja block keywords (like `if`, `for`, `set`, etc.) were being incorrectly stripped, causing the lexer to misidentify token types.

## Changes
- **jinja_formatter.rs**: Added `is_jinja_keyword_before_paren()` function to detect when a Jinja block keyword precedes a parenthesis. Modified the space-stripping logic to preserve the space in these cases, preventing the lexer from misidentifying constructs like `if (condition)` as something other than a JinjaBlockStart token.
- **Test coverage**: Added regression test file `225_dbt_snowflake_incremental_macro.sql` demonstrating the fix with complex dbt Snowflake materialization code containing multiple Jinja block keywords with parenthesized conditions.
- **Version bump**: Updated to 0.4.8

## Implementation Details
The fix checks if the word immediately before a `(` is a Jinja keyword by walking backwards through the string to identify word boundaries. The list of protected keywords includes: `if`, `elif`, `for`, `macro`, `call`, `set`, `test`, `snapshot`, `materialization`, `not`, `and`, `or`, `in`, and `is`. When such a keyword is detected, the trailing space is preserved to maintain proper lexer token identification.

https://claude.ai/code/session_01CAuKVomTpvot1if2cEEKBS