### PR TITLE
Fix UTF-8 handling in string processing functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/src/api.rs
+++ b/src/api.rs
@@ -403,6 +403,27 @@ fn normalize_token_text(text: &str, token_type: crate::token::TokenType) -> Stri
     }
 }
 
+/// Push the full UTF-8 character starting at `bytes[i]` into `result`.
+/// Returns the position after the character.
+/// SAFETY: caller must ensure that `bytes` is valid UTF-8.
+#[inline]
+fn push_utf8_char(bytes: &[u8], i: usize, result: &mut String) -> usize {
+    let b = bytes[i];
+    let char_len = if b < 0x80 {
+        1
+    } else if b < 0xE0 {
+        2
+    } else if b < 0xF0 {
+        3
+    } else {
+        4
+    };
+    let end = (i + char_len).min(bytes.len());
+    // SAFETY: input is valid UTF-8 and we are slicing at a character boundary
+    result.push_str(unsafe { std::str::from_utf8_unchecked(&bytes[i..end]) });
+    end
+}
+
 /// Normalize single-quoted string delimiters to double quotes for equivalence,
 /// without modifying single quotes that appear inside double-quoted strings.
 /// E.g. `'hello'` → `"hello"`, but `"'csnp', 'dual'"` stays unchanged.
@@ -418,9 +439,9 @@ fn normalize_jinja_quotes(text: &str) -> String {
             i += 1;
             while i < bytes.len() {
                 if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    result.push(bytes[i] as char);
-                    result.push(bytes[i + 1] as char);
-                    i += 2;
+                    result.push('\\');
+                    i += 1;
+                    i = push_utf8_char(bytes, i, &mut result);
                     continue;
                 }
                 if bytes[i] == b'"' {
@@ -435,8 +456,7 @@ fn normalize_jinja_quotes(text: &str) -> String {
                     i += 1;
                     break;
                 }
-                result.push(bytes[i] as char);
-                i += 1;
+                i = push_utf8_char(bytes, i, &mut result);
             }
         } else if bytes[i] == b'\'' {
             // Single-quoted string — check if it contains unescaped double quotes.
@@ -466,9 +486,9 @@ fn normalize_jinja_quotes(text: &str) -> String {
             i += 1;
             while i < bytes.len() {
                 if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    result.push(bytes[i] as char);
-                    result.push(bytes[i + 1] as char);
-                    i += 2;
+                    result.push('\\');
+                    i += 1;
+                    i = push_utf8_char(bytes, i, &mut result);
                     continue;
                 }
                 if bytes[i] == b'\'' {
@@ -483,12 +503,10 @@ fn normalize_jinja_quotes(text: &str) -> String {
                     i += 1;
                     break;
                 }
-                result.push(bytes[i] as char);
-                i += 1;
+                i = push_utf8_char(bytes, i, &mut result);
             }
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            i = push_utf8_char(bytes, i, &mut result);
         }
     }
     result
@@ -576,8 +594,7 @@ fn normalize_jinja_structure(text: &str) -> String {
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i = push_utf8_char(bytes, i, &mut result);
     }
     result
 }
@@ -619,8 +636,7 @@ fn normalize_jinja_operators(text: &str) -> String {
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i = push_utf8_char(bytes, i, &mut result);
     }
     result
 }

--- a/src/jinja_formatter.rs
+++ b/src/jinja_formatter.rs
@@ -184,6 +184,27 @@ impl JinjaFormatter {
         buf_a
     }
 
+    /// Push the full UTF-8 character starting at `bytes[i]` into `result`.
+    /// Returns the position after the character.
+    /// SAFETY: caller must ensure that `bytes` is valid UTF-8.
+    #[inline]
+    fn push_utf8_char(bytes: &[u8], i: usize, result: &mut String) -> usize {
+        let b = bytes[i];
+        let char_len = if b < 0x80 {
+            1
+        } else if b < 0xE0 {
+            2
+        } else if b < 0xF0 {
+            3
+        } else {
+            4
+        };
+        let end = (i + char_len).min(bytes.len());
+        // SAFETY: input is valid UTF-8 and we are slicing at a character boundary
+        result.push_str(unsafe { std::str::from_utf8_unchecked(&bytes[i..end]) });
+        end
+    }
+
     /// Normalize internal whitespace in Jinja content, respecting strings.
     /// Collapses runs of whitespace (including newlines) to single spaces,
     /// but preserves whitespace inside string literals.
@@ -213,8 +234,7 @@ impl JinjaFormatter {
                 result.push(' ');
                 in_whitespace = false;
             }
-            result.push(bytes[i] as char);
-            i += 1;
+            i = Self::push_utf8_char(bytes, i, &mut result);
         }
         result
     }
@@ -307,8 +327,7 @@ impl JinjaFormatter {
                 continue;
             }
 
-            result.push(bytes[i] as char);
-            i += 1;
+            i = Self::push_utf8_char(bytes, i, result);
         }
     }
 
@@ -325,8 +344,7 @@ impl JinjaFormatter {
             } else if bytes[i] == b'\'' {
                 i = Self::convert_single_quoted(content, bytes, i, &mut result);
             } else {
-                result.push(bytes[i] as char);
-                i += 1;
+                i = Self::push_utf8_char(bytes, i, &mut result);
             }
         }
         result
@@ -349,8 +367,7 @@ impl JinjaFormatter {
                     i += 3;
                     return i;
                 }
-                result.push(bytes[i] as char);
-                i += 1;
+                i = Self::push_utf8_char(bytes, i, result);
             }
             return i;
         }
@@ -358,16 +375,15 @@ impl JinjaFormatter {
         i += 1;
         while i < bytes.len() && bytes[i] != b'"' {
             if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                result.push(bytes[i] as char);
-                result.push(bytes[i + 1] as char);
-                i += 2;
+                result.push('\\');
+                i += 1;
+                i = Self::push_utf8_char(bytes, i, result);
                 continue;
             }
-            result.push(bytes[i] as char);
-            i += 1;
+            i = Self::push_utf8_char(bytes, i, result);
         }
         if i < bytes.len() {
-            result.push(bytes[i] as char);
+            result.push('"');
             i += 1;
         }
         i
@@ -508,8 +524,7 @@ impl JinjaFormatter {
                 continue;
             }
 
-            result.push(bytes[i] as char);
-            i += 1;
+            i = Self::push_utf8_char(bytes, i, result);
         }
     }
 
@@ -537,8 +552,7 @@ impl JinjaFormatter {
                 continue;
             }
 
-            result.push(bytes[i] as char);
-            i += 1;
+            i = Self::push_utf8_char(bytes, i, result);
         }
     }
 

--- a/src/jinja_formatter_test.rs
+++ b/src/jinja_formatter_test.rs
@@ -77,3 +77,29 @@ fn test_normalize_inner_whitespace() {
     let result = JinjaFormatter::normalize_inner_whitespace("'hello  world'");
     assert_eq!(result, "'hello  world'");
 }
+
+#[test]
+fn test_normalize_preserves_multibyte_utf8() {
+    let formatter = JinjaFormatter::new(88);
+
+    // Emoji in expression string
+    let result = formatter.normalize_expression(
+        r#"{{ exceptions.raise_compiler_error("❌ missing param") }}"#,
+    );
+    assert_eq!(
+        result,
+        Some(r#"{{ exceptions.raise_compiler_error("❌ missing param") }}"#.to_string()),
+    );
+
+    // Emoji outside quotes (in whitespace normalization path)
+    let result = JinjaFormatter::normalize_inner_whitespace("❌  error");
+    assert_eq!(result, "❌ error");
+
+    // Multi-byte chars in operator spacing path
+    let result = JinjaFormatter::add_operator_spaces("café + naïve");
+    assert_eq!(result, "café + naïve");
+
+    // Emoji preserved through quote normalization (single → double)
+    let result = JinjaFormatter::normalize_quotes("'❌ error'");
+    assert_eq!(result, r#""❌ error""#);
+}

--- a/src/jinja_formatter_test.rs
+++ b/src/jinja_formatter_test.rs
@@ -83,9 +83,8 @@ fn test_normalize_preserves_multibyte_utf8() {
     let formatter = JinjaFormatter::new(88);
 
     // Emoji in expression string
-    let result = formatter.normalize_expression(
-        r#"{{ exceptions.raise_compiler_error("❌ missing param") }}"#,
-    );
+    let result = formatter
+        .normalize_expression(r#"{{ exceptions.raise_compiler_error("❌ missing param") }}"#);
     assert_eq!(
         result,
         Some(r#"{{ exceptions.raise_compiler_error("❌ missing param") }}"#.to_string()),

--- a/tests/data/preformatted/304_jinjafmt_multibyte_utf8.sql
+++ b/tests/data/preformatted/304_jinjafmt_multibyte_utf8.sql
@@ -1,0 +1,25 @@
+{% test unique_dynamic_warehouse(model, column_name, snowflake_warehouse) %}
+    {% if snowflake_warehouse is none %}
+        {{
+            exceptions.raise_compiler_error(
+                "❌ 'snowflake_warehouse' parameter must not be null in production. Please provide a valid warehouse name."
+            )
+        }}
+    {% endif %}
+    {% if target.name == "prod" %}
+        {{ config(snowflake_warehouse=snowflake_warehouse) }}
+    {% endif %}
+    with
+        duplicates as (
+            select
+                {{ column_name }} as duplicate_value
+                , count(*) as duplicate_count
+            from {{ model }}
+            group by {{ column_name }}
+            having count(*) > 1
+        )
+    select
+        duplicate_value
+        , duplicate_count
+    from duplicates
+{% endtest %}


### PR DESCRIPTION
## Summary
This PR fixes incorrect handling of multi-byte UTF-8 characters in the Jinja formatter and API functions. Previously, the code was casting individual bytes to `char`, which corrupted multi-byte UTF-8 sequences. This change introduces proper UTF-8 character boundary detection and handling.

## Key Changes
- **Added `push_utf8_char()` helper function** in both `jinja_formatter.rs` and `api.rs` that:
  - Detects UTF-8 character length by examining the first byte
  - Safely extracts the full multi-byte sequence
  - Pushes the complete character to the result string
  
- **Replaced all `bytes[i] as char` casts** with calls to `push_utf8_char()` in:
  - `normalize_inner_whitespace()`
  - `normalize_expression()`
  - `normalize_quotes()`
  - `convert_double_quoted()`
  - `add_operator_spaces()`
  - `normalize_jinja_structure()`
  - `normalize_jinja_operators()`
  - `normalize_jinja_quotes()` in api.rs

- **Fixed escape sequence handling** in `convert_double_quoted()` and `normalize_jinja_quotes()` to properly handle backslash escapes with multi-byte characters

- **Added comprehensive test coverage** for multi-byte UTF-8 characters (emoji and accented characters) across multiple code paths

## Implementation Details
The UTF-8 character length detection uses the standard UTF-8 encoding scheme:
- `0xxxxxxx` (< 0x80): 1 byte
- `110xxxxx` (< 0xE0): 2 bytes  
- `1110xxxx` (< 0xF0): 3 bytes
- `11110xxx`: 4 bytes

The implementation uses `unsafe { std::str::from_utf8_unchecked() }` which is safe because the input is guaranteed to be valid UTF-8 and we're slicing at proper character boundaries.

https://claude.ai/code/session_015m8Sb1EHFjDELvkqCDazH7