### PR TITLE
Add strict whitespace mode for rejecting whitespace-only input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,8 +19,15 @@ struct TokenSnapshot {
 /// Format a SQL string according to the given mode.
 /// This is the core API function.
 pub fn format_string(source: &str, mode: &Mode) -> Result<String, SqlfmtError> {
-    // Whitespace-only input (spaces, tabs, newlines) is treated as empty.
+    // Whitespace-only input (spaces, tabs, newlines) is treated as empty
+    // unless strict_whitespace mode is enabled.
     if source.trim().is_empty() {
+        if mode.strict_whitespace {
+            return Err(SqlfmtError::Parsing {
+                position: 0,
+                message: "Input contains only whitespace".to_string(),
+            });
+        }
         return Ok(String::new());
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,6 +19,11 @@ struct TokenSnapshot {
 /// Format a SQL string according to the given mode.
 /// This is the core API function.
 pub fn format_string(source: &str, mode: &Mode) -> Result<String, SqlfmtError> {
+    // Whitespace-only input (spaces, tabs, newlines) is treated as empty.
+    if source.trim().is_empty() {
+        return Ok(String::new());
+    }
+
     let dialect = mode.dialect()?;
 
     let mut analyzer = dialect.initialize_analyzer(mode.line_length);

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,10 @@ fn main() {
         Err(_) => 0,
     };
 
+    let env_strict_whitespace = std::env::var("SQLFMT_STRICT_WHITESPACE")
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+
     let mode = Mode {
         line_length: cli.line_length,
         dialect_name: cli.dialect,
@@ -114,6 +118,7 @@ fn main() {
             env_threads
         },
         single_process: cli.single_process,
+        strict_whitespace: env_strict_whitespace,
     };
 
     if is_stdin {

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -42,6 +42,11 @@ pub struct Mode {
 
     #[serde(default)]
     pub single_process: bool,
+
+    /// When true, whitespace-only input is treated as a parse error
+    /// instead of returning an empty string.
+    #[serde(default)]
+    pub strict_whitespace: bool,
 }
 
 fn default_line_length() -> usize {
@@ -81,6 +86,7 @@ impl Default for Mode {
             quiet: false,
             threads: 0,
             single_process: false,
+            strict_whitespace: false,
         }
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -162,6 +162,17 @@ fn test_stdin_whitespace_with_tabs_and_newlines() {
 }
 
 #[test]
+fn test_stdin_strict_whitespace_env_var() {
+    sqlfmt()
+        .arg("-")
+        .env("SQLFMT_STRICT_WHITESPACE", "1")
+        .write_stdin("   ")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("only whitespace"));
+}
+
+#[test]
 fn test_stdin_normalizes_trailing_newline() {
     sqlfmt()
         .arg("-")

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -148,6 +148,20 @@ fn test_stdin_empty_input() {
 }
 
 #[test]
+fn test_stdin_whitespace_only() {
+    sqlfmt().arg("-").write_stdin("   ").assert().success();
+}
+
+#[test]
+fn test_stdin_whitespace_with_tabs_and_newlines() {
+    sqlfmt()
+        .arg("-")
+        .write_stdin("  \t  \n  \t  \n")
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_stdin_normalizes_trailing_newline() {
     sqlfmt()
         .arg("-")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,6 +14,24 @@ fn test_format_empty_whitespace() {
 }
 
 #[test]
+fn test_format_spaces_only() {
+    let result = format_string("   ", &default_mode()).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_format_tabs_and_spaces() {
+    let result = format_string("  \t  \t  ", &default_mode()).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_format_mixed_whitespace_with_newlines() {
+    let result = format_string("  \n  \t  \n", &default_mode()).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
 fn test_very_long_single_line() {
     let long_name = "a".repeat(500);
     let source = format!("SELECT {}\n", long_name);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -32,6 +32,22 @@ fn test_format_mixed_whitespace_with_newlines() {
 }
 
 #[test]
+fn test_format_whitespace_strict_mode_errors() {
+    let mut mode = default_mode();
+    mode.strict_whitespace = true;
+    let result = format_string("   ", &mode);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_format_whitespace_strict_mode_allows_valid_sql() {
+    let mut mode = default_mode();
+    mode.strict_whitespace = true;
+    let result = format_string("SELECT 1\n", &mode);
+    assert!(result.is_ok());
+}
+
+#[test]
 fn test_very_long_single_line() {
     let long_name = "a".repeat(500);
     let source = format!("SELECT {}\n", long_name);


### PR DESCRIPTION
## Summary
This PR adds a new `strict_whitespace` mode that treats whitespace-only input as a parse error instead of silently returning an empty string. This provides stricter validation for SQL formatting workflows that should reject empty or whitespace-only files.

## Key Changes
- Added `strict_whitespace` boolean field to the `Mode` struct (defaults to `false` for backward compatibility)
- Implemented whitespace-only input detection in `format_string()` that:
  - Returns an empty string by default (existing behavior)
  - Returns a parse error when `strict_whitespace` is enabled
- Added environment variable support via `SQLFMT_STRICT_WHITESPACE` (accepts "1", "true", or "yes")
- Added comprehensive test coverage for both default and strict modes:
  - Integration tests for spaces-only, tabs, mixed whitespace, and newlines
  - CLI tests for stdin handling with whitespace-only input
  - CLI test for strict mode environment variable behavior
- Bumped version to 0.4.11

## Implementation Details
- The whitespace check uses `source.trim().is_empty()` to detect whitespace-only input before any parsing occurs
- Error message is clear: "Input contains only whitespace"
- Environment variable parsing is case-insensitive and flexible
- All changes are backward compatible; strict mode is opt-in via environment variable

https://claude.ai/code/session_015afj2oMJrRFa6MhWi4XJXY