### PR TITLE
Add test cases for Jinja formatting and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlfmt"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlfmt"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 autobenches = false
 description = "An opinionated SQL formatter, ported from Python sqlfmt. Optimized for Snowflake and DuckDB."

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ An opinionated SQL formatter written in Rust. Ported from [Python sqlfmt](https:
 Prebuilt binaries are available for Linux and macOS from
 [GitHub Releases](https://github.com/datastx/sqlfmt-rust/releases/latest).
 
-> **Note:** Replace `VERSION` below with the release version (e.g. `v0.4.12`).
+> **Note:** Replace `VERSION` below with the release version (e.g. `v0.4.13`).
 > Check the [releases page](https://github.com/datastx/sqlfmt-rust/releases/latest)
 > for the latest version.
 
 **Linux (x86_64):**
 
 ```bash
-VERSION=v0.4.12
+VERSION=v0.4.13
 curl -fsSL "https://github.com/datastx/sqlfmt-rust/releases/download/${VERSION}/sqlfmt-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
   | tar xz
 sudo mv "sqlfmt-${VERSION}-x86_64-unknown-linux-musl/sqlfmt" /usr/local/bin/
@@ -25,7 +25,7 @@ sudo mv "sqlfmt-${VERSION}-x86_64-unknown-linux-musl/sqlfmt" /usr/local/bin/
 **Linux (aarch64 / ARM64):**
 
 ```bash
-VERSION=v0.4.12
+VERSION=v0.4.13
 curl -fsSL "https://github.com/datastx/sqlfmt-rust/releases/download/${VERSION}/sqlfmt-${VERSION}-aarch64-unknown-linux-musl.tar.gz" \
   | tar xz
 sudo mv "sqlfmt-${VERSION}-aarch64-unknown-linux-musl/sqlfmt" /usr/local/bin/
@@ -34,7 +34,7 @@ sudo mv "sqlfmt-${VERSION}-aarch64-unknown-linux-musl/sqlfmt" /usr/local/bin/
 **macOS (Apple Silicon):**
 
 ```bash
-VERSION=v0.4.12
+VERSION=v0.4.13
 curl -fsSL "https://github.com/datastx/sqlfmt-rust/releases/download/${VERSION}/sqlfmt-${VERSION}-aarch64-apple-darwin.tar.gz" \
   | tar xz
 sudo mv "sqlfmt-${VERSION}-aarch64-apple-darwin/sqlfmt" /usr/local/bin/
@@ -43,7 +43,7 @@ sudo mv "sqlfmt-${VERSION}-aarch64-apple-darwin/sqlfmt" /usr/local/bin/
 **macOS (Intel):**
 
 ```bash
-VERSION=v0.4.12
+VERSION=v0.4.13
 curl -fsSL "https://github.com/datastx/sqlfmt-rust/releases/download/${VERSION}/sqlfmt-${VERSION}-x86_64-apple-darwin.tar.gz" \
   | tar xz
 sudo mv "sqlfmt-${VERSION}-x86_64-apple-darwin/sqlfmt" /usr/local/bin/

--- a/tests/data/errors/930_jinja_snowflake_external_table.sql
+++ b/tests/data/errors/930_jinja_snowflake_external_table.sql
@@ -1,0 +1,91 @@
+{% macro snowflake__create_external_table(source_node) %}
+
+    {%- set columns = source_node.columns.values() -%}
+    {%- set external = source_node.external -%}
+    {%- set partitions = external.partitions -%}
+    {%- set infer_schema = external.infer_schema -%}
+    {%- set ignore_case = external.ignore_case or false  -%}
+
+    {% if infer_schema %}
+        {% set query_infer_schema %}
+            select * from table( infer_schema( location=>'{{external.location}}', file_format=>'{{external.file_format}}', ignore_case=> {{ ignore_case }}) )
+        {% endset %}
+        {% if execute %}
+            {% set columns_infer = run_query(query_infer_schema) %}
+        {% endif %}
+    {% endif %}
+
+    {%- set is_csv = dbt_external_tables.is_csv(external.file_format) -%}
+
+{# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
+{# This assumes you have already created an external stage #}
+
+{% set ddl %}
+    create or replace external table {{source(source_node.source_name, source_node.name)}}
+    {%- if columns or partitions or infer_schema -%}
+    (
+        {%- if partitions -%}{%- for partition in partitions %}
+            {{partition.name}} {{partition.data_type}} as {{partition.expression}}{{- ',' if not loop.last or columns|length > 0 or infer_schema -}}
+        {%- endfor -%}{%- endif -%}
+        {%- if not infer_schema -%}
+            {%- for column in columns %}
+                {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
+                {%- set column_alias -%}
+                    {%- if 'alias' in column and column.quote -%}
+                        {{adapter.quote(column.alias)}}
+                    {%- elif 'alias' in column -%}
+                        {{column.alias}}
+                    {%- else -%}
+                        {{column_quoted}}
+                    {%- endif -%}
+                {%- endset %}
+                {%- set col_expression -%}
+                    {%- if column.expression -%}
+                        {{column.expression}}
+                    {%- else -%}
+                        {%- if ignore_case -%}
+                        {%- set col_id = 'value:c' ~ loop.index if is_csv else 'GET_IGNORE_CASE($1, ' ~ "'"~ column_quoted ~"'"~ ')' -%}
+                        {%- else -%}
+                        {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_quoted -%}
+                        {%- endif -%}
+                        (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
+                    {%- endif -%}
+                {%- endset %}
+                {{column_alias}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})
+                {{- ',' if not loop.last -}}
+            {% endfor %}
+        {% else %}
+        {%- for column in columns_infer %}
+                {%- set col_expression -%}
+                {%- if ignore_case -%}
+                    {%- set col_id = 'GET_IGNORE_CASE($1, ' ~ "'"~ column[0] ~"'"~ ')' -%}
+                {%- else -%}
+                    {%- set col_id = 'value:' ~ column[0] -%}
+                {%- endif -%}
+                    (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
+                {%- endset %}
+                {{column[0]}} {{column[1]}} as ({{col_expression}}::{{column[1]}})
+                {{- ',' if not loop.last -}}
+            {% endfor %}
+        {%- endif -%}
+    )
+    {%- endif -%}
+    {% if partitions %} partition by ({{partitions|map(attribute='name')|join(', ')}}) {% endif %}
+    location = {{external.location}} {# stage #}
+    {% if external.auto_refresh in (true, false) -%}
+      auto_refresh = {{external.auto_refresh}}
+    {%- endif %}
+    {% if external.aws_sns_topic -%}
+      aws_sns_topic = '{{external.aws_sns_topic}}'
+    {%- endif %}
+    {% if external.table_format | lower == "delta" %}
+      refresh_on_create = false
+    {% endif %}
+    {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
+    {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
+    file_format = {{external.file_format}}
+    {% if external.table_format -%} table_format = '{{external.table_format}}' {%- endif %}
+{% endset %}
+{# {{ log('ddl: ' ~ ddl, info=True) }} #}
+{{ ddl }};
+{% endmacro %}

--- a/tests/data/errors/931_jinja_unmatched_closing_brace.sql
+++ b/tests/data/errors/931_jinja_unmatched_closing_brace.sql
@@ -1,0 +1,11 @@
+{% macro get_row_count(full_table_name) %}
+
+    {% set query_row_count %}
+        select count(*) from {{ full_table_name }}
+    {% endset %}
+    {% if execute %}
+        {% set result = elementary.run_query(query_row_count).columns[0].values()[0] %}
+    {% endif %}
+    {{ return(result) }}
+
+{% endmacro %}}

--- a/tests/data/unformatted/302_jinja_compare_row_counts.sql
+++ b/tests/data/unformatted/302_jinja_compare_row_counts.sql
@@ -1,0 +1,40 @@
+{% set a_relation=ref('data_compare_relations__a_relation')%}
+
+{% set b_relation=ref('data_compare_relations__b_relation') %}
+
+select
+    case
+        when relation_name = '{{ a_relation }}'
+            then 'a'
+        else 'b'
+    end as relation_name,
+    total_records
+
+from (
+
+    {{ audit_helper.compare_row_counts(
+        a_relation=a_relation,
+        b_relation=b_relation
+    ) }}
+
+) as base_query
+)))))__SQLFMT_OUTPUT__(((((
+{% set a_relation = ref("data_compare_relations__a_relation") %}
+
+{% set b_relation = ref("data_compare_relations__b_relation") %}
+
+select
+    case when relation_name = '{{ a_relation }}' then 'a' else 'b' end as relation_name
+    , total_records
+
+from
+    (
+
+        {{
+            audit_helper.compare_row_counts(
+                a_relation=a_relation,
+                b_relation=b_relation,
+            )
+        }}
+
+    ) as base_query

--- a/tests/data/unformatted/303_jinja_audit_helper_queries.sql
+++ b/tests/data/unformatted/303_jinja_audit_helper_queries.sql
@@ -1,0 +1,25 @@
+{{ config(tags=['skip' if (target.type in ['redshift', 'postgres', 'databricks']) else 'runnable']) }}
+
+{{
+    audit_helper.quick_are_queries_identical(
+        "select * from " ~ ref('unit_test_model_a') ~ " where 1=1",
+        "select * from " ~ ref('unit_test_model_b') ~ " where 1=1",
+        columns=var('quick_are_queries_identical_cols'),
+        event_time=var('event_time_var')
+    )
+}}
+)))))__SQLFMT_OUTPUT__(((((
+{{
+    config(
+        tags=["skip" if (target.type in ["redshift", "postgres", "databricks"]) else "runnable"]
+    )
+}}
+
+{{
+    audit_helper.quick_are_queries_identical(
+        "select * from " ~ ref("unit_test_model_a") ~ " where 1=1",
+        "select * from " ~ ref("unit_test_model_b") ~ " where 1=1",
+        columns=var("quick_are_queries_identical_cols"),
+        event_time=var("event_time_var"),
+    )
+}}

--- a/tests/data/unformatted/304_jinja_test_unstructured_data.sql
+++ b/tests/data/unformatted/304_jinja_test_unstructured_data.sql
@@ -1,0 +1,22 @@
+{% test unstructured_data_validation(model, column_name, expectation_prompt, llm_model_name=none) %}
+    {{ config(tags = ['elementary-tests']) }}
+    {% set prompt_context = "You are a data validator specializing in validating unstructured data." %}
+    {{ return(elementary.test_ai_data_validation(model, column_name, expectation_prompt, llm_model_name, prompt_context)) }}
+{% endtest %}
+)))))__SQLFMT_OUTPUT__(((((
+{% test unstructured_data_validation(
+    model,
+    column_name,
+    expectation_prompt,
+    llm_model_name=none
+) %}
+    {{ config(tags = ["elementary-tests"]) }}
+    {% 
+        set prompt_context = "You are a data validator specializing in validating unstructured data."
+    %}
+    {{
+        return(
+            elementary.test_ai_data_validation(model, column_name, expectation_prompt, llm_model_name, prompt_context)
+        )
+    }}
+{% endtest %}

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -124,6 +124,9 @@ golden_tests! {
     // =========================================================================
     golden_unformatted_300_jinjafmt => (default_mode, "tests/data/unformatted/300_jinjafmt.sql"),
     golden_unformatted_301_jinja_macro_method_chains => (default_mode, "tests/data/unformatted/301_jinja_macro_method_chains.sql"),
+    golden_unformatted_302_jinja_compare_row_counts => (default_mode, "tests/data/unformatted/302_jinja_compare_row_counts.sql"),
+    golden_unformatted_303_jinja_audit_helper_queries => (default_mode, "tests/data/unformatted/303_jinja_audit_helper_queries.sql"),
+    golden_unformatted_304_jinja_test_unstructured_data => (default_mode, "tests/data/unformatted/304_jinja_test_unstructured_data.sql"),
 
     // =========================================================================
     // Unformatted 400-series — DDL/DML
@@ -158,4 +161,6 @@ golden_error_tests! {
     golden_error_910_unopened_multiline => "tests/data/errors/910_unopened_multiline.sql",
     golden_error_911_unopened_bracket => "tests/data/errors/911_unopened_bracket.sql",
     golden_error_920_unterminated_multiline => "tests/data/errors/920_unterminated_multiline.sql",
+    golden_error_930_jinja_snowflake_external_table => "tests/data/errors/930_jinja_snowflake_external_table.sql",
+    golden_error_931_jinja_unmatched_closing_brace => "tests/data/errors/931_jinja_unmatched_closing_brace.sql",
 }


### PR DESCRIPTION
## Summary
This release adds comprehensive test coverage for Jinja template formatting and error detection, along with a version bump to v0.4.13.

## Key Changes
- **New test cases for Jinja formatting:**
  - `302_jinja_compare_row_counts.sql`: Tests formatting of audit helper comparison queries with proper indentation and quote normalization
  - `303_jinja_audit_helper_queries.sql`: Tests formatting of audit helper quick comparison queries with config tag formatting
  - `304_jinja_test_unstructured_data.sql`: Tests formatting of custom Jinja test macros with proper parameter and function call formatting

- **New error test cases:**
  - `930_jinja_snowflake_external_table.sql`: Complex Snowflake external table creation macro with conditional logic and schema inference
  - `931_jinja_unmatched_closing_brace.sql`: Tests error detection for unmatched closing braces in Jinja macros

- **Version and documentation updates:**
  - Bumped version from 0.4.12 to 0.4.13 in `Cargo.toml`
  - Updated installation instructions in README.md to reference v0.4.13
  - Registered new golden tests in `golden_test.rs`

## Notable Details
The new test cases cover real-world dbt and Jinja patterns including:
- Complex nested Jinja control flow and variable assignments
- Macro parameter formatting and function chaining
- Snowflake-specific external table syntax with conditional clauses
- Error cases for malformed Jinja syntax

https://claude.ai/code/session_01UAtdLC43De9cf1Eo9r4f6i